### PR TITLE
feat: add iso 15693 vicinity reader support

### DIFF
--- a/src/hydrabus/commands.c
+++ b/src/hydrabus/commands.c
@@ -483,7 +483,7 @@ t_token tokens_connect_auto_opt[] = {
 	},\
 	{\
 		T_CARD_CONNECT_AUTO,\
-		.help = "Connect to a smartcard (ISO 14443 A & B)"\
+		.help = "Connect to a smartcard (ISO 14443 A & B) or ISO 15693/Vicinity card"\
 	},\
 	{\
 		T_CARD_CONNECT_AUTO_OPT,               \
@@ -493,7 +493,7 @@ t_token tokens_connect_auto_opt[] = {
 	{\
 		T_CARD_SEND,         \
 		.arg_type = T_ARG_STRING,              \
-		.help = "Send APDU data to a card initialized with the connect command (only ISO 14443 A & B tags)"\
+		.help = "Send APDU data to a card initialized with the connect command (only ISO 14443 A & B tags), or data with automatic CRC computation for ISO 15693/Vicinity cards."\
 	},\
 /*
 	{\

--- a/src/hydranfc_v2/hydranfc_v2_dnfc_mode.c
+++ b/src/hydranfc_v2/hydranfc_v2_dnfc_mode.c
@@ -446,10 +446,13 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			}
 
 			rfalGetBitRate(&txBR, &rxBR);
-			if( (txBR != RFAL_BR_106) & (rxBR != RFAL_BR_106)){
-				cprintf(con, "Error. Only RFAL_BR_106 (0) for Rx & Tx (0) supported.\r\n");
-				cprintf(con, "Update parameters with set-nfc-mode nfc-mode-tx_br XXX or set-nfc-mode nfc-mode-rx_br XXX commands.\r\n");
-				break;
+
+			if (mode != RFAL_MODE_POLL_NFCV) {
+				if ((txBR != RFAL_BR_106) & (rxBR != RFAL_BR_106)) {
+						cprintf (con, "Error. Only RFAL_BR_106 (0) for Rx & Tx (0) supported.\r\n");
+						cprintf (con, "Update parameters with set-nfc-mode nfc-mode-tx_br XXX or set-nfc-mode nfc-mode-rx_br XXX commands.\r\n");
+						break;
+					}
 			}
 
 			rfalSetErrorHandling( RFAL_ERRORHANDLING_NFC );


### PR DESCRIPTION
# Add ISO 15694/Vicinity reader support

## dnfc menu

```
dnfc2> set-nfc-mode nfc-mode 7 nfc-mode-tx_br 236 nfc-mode-rx_br 236
nfc-mode = 7
nfc-mode-tx_br = 236
nfc-mode-rx_br = 236
rfalSetMode OK
dnfc2> rf-off-on
dnfc2> send-auto 260100  
00 00 F5 3F CC 6F 50 01 04 E0 
```

## nfc menu

```
> nfc
NFCv2> connect
> 26
Error 4
> 05 00 00 
< 
Error 4
> 26 01 00 
< 00 00 F5 3F CC 6F 50 01 04 E0 
ISO 15693 (Vicinity) card detected.
NFCv2> send 222BF53FCC6F500104E0
> 22 2B F5 3F CC 6F 50 01 04 E0 
< 00 0F F5 3F CC 6F 50 01 04 E0 00 00 1B 03 01 
```