### PR TITLE
Bbio card emulator iso14443 a

### DIFF
--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Low level script to show how to emulate an ISO 14443-A card
+# You shall use https://github.com/hydrabus/pyHydrabus or https://github.com/gvinet/pynfcreader to have a user-friendly high level API
+#
+# Author: Guillaume VINET <guillaume.vinet@gmail.com>
+# License: GPLv3 (https://choosealicense.com/licenses/gpl-3.0/)
+#
+import serial
+
+port = "/dev/ttyACM2"
+
+ser = serial.Serial(port, timeout=None)
+
+
+# We enter BBIO1 MODE
+def enter_bbio(ser):
+    ser.timeout = 0.01
+    for _ in range(20):
+        ser.write(b"\x00")
+        if b"BBIO1" in ser.read(5):
+            ser.reset_input_buffer()
+            ser.timeout = None
+
+            # We enter reader mode
+            ser.write(b"\x17")
+            if ser.read(4) != b"NCE2":
+                raise Exception("Cannot enter BBIO Reader mode")
+            return
+    raise Exception("Cannot enter BBIO mode.")
+
+
+enter_bbio(ser)
+
+print("Card emulator")
+ser.write(b"\x01")
+
+print("Cmd")
+print(ser.read(40).hex())
+
+while 1:
+    cmd_len = int.from_bytes(ser.read(2), byteorder="little")
+    print(f"Len: {cmd_len}")
+    cmd = ser.read(cmd_len)
+    print(f"Cmd {cmd.hex()}")
+
+    resp = bytes.fromhex("CAFEBABE9000")
+    resp_len = len(resp)
+    ser.write(resp_len.to_bytes(2, byteorder="little"))
+    ser.write(resp)

--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
@@ -25,7 +25,7 @@ def enter_bbio(ser):
             # We enter reader mode
             ser.write(b"\x17")
             if ser.read(4) != b"NCE2":
-                raise Exception("Cannot enter BBIO Reader mode")
+                raise Exception("Cannot enter BBIO Card Emulator mode")
             return
     raise Exception("Cannot enter BBIO mode.")
 

--- a/src/hydrabus/hydrabus_bbio.c
+++ b/src/hydrabus/hydrabus_bbio.c
@@ -43,6 +43,7 @@
 
 #ifdef HYDRANFC_V2
 #include "hydranfc_v2_bbio_reader.h"
+#include "hydranfc_v2_bbio_card_emulator.h"
 #endif
 
 int cmd_bbio(t_hydra_console *con)
@@ -102,11 +103,15 @@ int cmd_bbio(t_hydra_console *con)
 				break;
 #endif
 
-//#ifdef HYDRANFC_V2
+#ifdef HYDRANFC_V2
 			case BBIO_NFC_V2_READER:
 				bbio_mode_hydranfc_v2_reader(con);
 				break;
-//#endif
+
+			case BBIO_NFC_V2_CARD_EMULATOR:
+				bbio_mode_hydranfc_v2_card_emulator(con);
+				break;
+#endif
 
 			case BBIO_RESET_HW:
 				/* Needed for flashrom detection */

--- a/src/hydrabus/hydrabus_bbio.h
+++ b/src/hydrabus/hydrabus_bbio.h
@@ -48,6 +48,7 @@
 #define BBIO_VOLT	0b00010100
 #define BBIO_VOLT_CONT	0b00010101
 #define BBIO_FREQ	0b00010110
+#define BBIO_NFC_V2_CARD_EMULATOR	0b00010111
 
 /*
  * SPI-specific commands
@@ -184,7 +185,7 @@
 #define BBIO_AUX_MODE_SET	0b11110000
 
 /*
- * Hydra NFC specific comamnds
+ * Hydra NFC specific commands
  */
 #define BBIO_NFC_RF_OFF			0b00000010
 #define BBIO_NFC_RF_ON			0b00000011
@@ -194,5 +195,8 @@
 #define BBIO_NFC_SET_MODE_ISO_15693	0b00000111
 #define BBIO_NFC_ISO_14443_A_REQA 0b00001000
 #define BBIO_NFC_SET_MODE_ISO_14443B	0b00001001
+
+#define BBIO_NFC_CE_START_EMULATION    0b00000001
+#define BBIO_NFC_CE_GET_RX             0b00000011
 
 int cmd_bbio(t_hydra_console *con);

--- a/src/hydranfc_v2/hydranfc_v2.mk
+++ b/src/hydranfc_v2/hydranfc_v2.mk
@@ -5,7 +5,8 @@ HYDRANFC_V2_SRC = hydranfc_v2/hydranfc_v2_nfc_mode.c \
                   hydranfc_v2/ce.c \
                   hydranfc_v2/rfal_poller.c \
                   hydranfc_v2/hydranfc_v2_bbio_reader.c \
-                  hydranfc_v2/hydranfc_v2_reader.c
+                  hydranfc_v2/hydranfc_v2_reader.c \
+                  hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
 
 
 # Required include directories

--- a/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
+++ b/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
@@ -1,0 +1,253 @@
+/*
+ * HydraBus/HydraNFC
+ *
+ * Copyright (C) 2020 Guillaume VINET
+ * Copyright (C) 2014-2020 Benjamin VERNOUX
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "common.h"
+#include "tokenline.h"
+#include "hydranfc_v2_nfc_mode.h"
+#include "rfal_rf.h"
+#include "hydrabus_bbio.h"
+#include "hydranfc_v2_bbio_card_emulator.h"
+#include "hydranfc_v2_ce.h"
+#include "st25r3916.h"
+#include "st25r3916_irq.h"
+#include "st25r3916_com.h"
+#include "rfal_analogConfig.h"
+#include "rfal_rf.h"
+#include "rfal_nfca.h"
+#include "rfal_nfcb.h"
+#include "rfal_nfcv.h"
+
+#include <string.h>
+
+static volatile int irq_count;
+static volatile int irq;
+static volatile int irq_end_rx;
+
+static void (* st25r3916_irq_fn)(void) = NULL;
+
+extern sUserTagProperties user_tag_properties;
+extern void hydranfc_ce_set_processCmd_ptr(void * ptr);
+
+/* Triggered when the Ext IRQ is pressed or released. */
+static void extcb1(void * arg)
+{
+	(void) arg;
+
+	if(st25r3916_irq_fn != NULL)
+		st25r3916_irq_fn();
+
+	irq_count++;
+	irq = 1;
+}
+
+extern t_mode_config mode_con1;
+static t_hydra_console * g_con;
+
+static ReturnCode hydranfc_v2_init_RFAL(t_hydra_console *con)
+{
+	ReturnCode err;
+	/* RFAL initalisation */
+	rfalAnalogConfigInitialize();
+	err = rfalInitialize();
+	if(err != ERR_NONE) {
+		cprintf(con, "hydranfc_v2_init_RFAL rfalInitialize() error=%d\r\n", err);
+		return err;
+	}
+
+	/* DPO setup */
+#ifdef DPO_ENABLE
+	rfalDpoInitialize();
+	rfalDpoSetMeasureCallback( rfalChipMeasureAmplitude );
+	err = rfalDpoTableWrite(dpoSetup,sizeof(dpoSetup)/sizeof(rfalDpoEntry));
+	if(err != ERR_NONE) {
+		cprintf(con, "hydranfc_v2_init_RFAL rfalDpoTableWrite() error=%d\r\n", err);
+		return err;
+	}
+	rfalDpoSetEnabled(true);
+	rfalSetPreTxRxCallback(&rfalPreTransceiveCb);
+#endif
+	return err;
+}
+
+
+static bool init_gpio_spi_nfc(t_hydra_console *con)
+{
+	/*
+	 * Initializes the SPI driver 2. The SPI2 signals are routed as follow:
+	 * ST25R3916 IO4_CS SPI mode / HydraBus PC1 - NSS
+	 * ST25R3916 DATA_CLK SPI mode / HydraBus PB10 - SCK
+	 * ST25R3916 IO6_MISO SPI mode / HydraBus PC2 - MISO
+	 * ST25R3916 IO7_MOSI SPI mode / HydraBus PC3 - MOSI
+	 * Used for communication with ST25R3916 in SPI mode with NSS.
+	 */
+	mode_con1.proto.config.spi.dev_gpio_pull = MODE_CONFIG_DEV_GPIO_NOPULL;
+	//mode_con1.proto.config.spi.dev_speed = 5; /* 5 250 000 Hz */
+	mode_con1.proto.config.spi.dev_speed = 6; /* 10 500 000 Hz */
+	mode_con1.proto.config.spi.dev_phase = 1;
+	mode_con1.proto.config.spi.dev_polarity = 0;
+	mode_con1.proto.config.spi.dev_bit_lsb_msb = DEV_FIRSTBIT_MSB;
+	mode_con1.proto.config.spi.dev_mode = DEV_MASTER;
+	bsp_spi_init(BSP_DEV_SPI2, &mode_con1.proto);
+
+	/*
+	 * Initializes the SPI driver 1. The SPI1 signals are routed as follows:
+	 * Shall be configured as SPI Slave for ST25R3916 NFC data sampling on MOD pin.
+	 * NSS. (Not used use Software).
+	 * ST25R3916 MCU_CLK pin28 output / HydraBus PA5 - SCK.(AF5) => SPI Slave CLK input (Sniffer mode/RX Transparent Mode)
+	 * ST25R3916 ST25R3916 MOSI SPI pin31 (IN) / HydraBus PA6 - MISO.(AF5) (MCU TX Transparent Mode)
+	 * ST25R3916 ST25R3916 MISO_SDA pin32 (OUT) / HydraBus PA7 - MOSI.(AF5) => SPI Slave MOSI input (Sniffer mode/RX Transparent Mode)
+	 */
+	/* spiStart() is done in sniffer see sniffer.c */
+	/* HydraBus SPI1 Slave CLK input */
+	palSetPadMode(GPIOA, 5, PAL_MODE_ALTERNATE(5) | PAL_STM32_OSPEED_MID1);
+	/* HydraBus SPI1 Slave MISO. Not used/Not connected */
+	palSetPadMode(GPIOA, 6, PAL_MODE_ALTERNATE(5) | PAL_STM32_OSPEED_MID1);
+	/* HydraBus SPI1 Slave MOSI. connected to ST25R3916 MOD Pin */
+	palSetPadMode(GPIOA, 7, PAL_MODE_ALTERNATE(5) | PAL_STM32_OSPEED_MID1);
+
+	/* Configure K1/2 Buttons as Input */
+	palSetPadMode(GPIOB, 8, PAL_MODE_INPUT); /* K1 Button */
+	palSetPadMode(GPIOB, 9, PAL_MODE_INPUT); /* K2 Button */
+
+	/* Configure D1/2/3/4 LEDs as Output */
+	D1_OFF;
+	D2_OFF;
+	D3_OFF;
+	D4_OFF;
+
+	palSetPadMode(GPIOB, 0, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+
+#ifndef MAKE_DEBUG
+	// can't use LED on PB3 if using SWO
+	palSetPadMode(GPIOB, 3, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+#endif
+
+	palSetPadMode(GPIOB, 4, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+	palSetPadMode(GPIOB, 5, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+
+	palDisablePadEvent(GPIOA, 1);
+	/* ST25R3916 IRQ output / HydraBus PA1 input */
+	palClearPad(GPIOA, 1);
+	palSetPadMode(GPIOA, 1, PAL_MODE_INPUT | PAL_STM32_OSPEED_MID1);
+	/* Activates the PAL driver callback */
+	//palDisablePadEvent(GPIOA, 1);
+	palEnablePadEvent(GPIOA, 1, PAL_EVENT_MODE_RISING_EDGE);
+	palSetPadCallback(GPIOA, 1, &extcb1, NULL);
+
+	/* Init st25r3916 IRQ function callback */
+	st25r3916_irq_fn = st25r3916Isr;
+	hal_st25r3916_spiInit(ST25R391X_SPI_DEVICE);
+	if (hydranfc_v2_init_RFAL(con) != ERR_NONE) {
+		cprintf(con, "HydraNFC v2 not found.\r\n");
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static void deinit_gpio_spi_nfc(t_hydra_console *con)
+{
+	(void)(con);
+	palClearPad(GPIOA, 1);
+	palSetPadMode(GPIOA, 1, PAL_MODE_INPUT);
+	palDisablePadEvent(GPIOA, 1);
+
+	bsp_spi_deinit(BSP_DEV_SPI2);
+
+	palSetPadMode(GPIOA, 5, PAL_MODE_INPUT);
+	palSetPadMode(GPIOA, 6, PAL_MODE_INPUT);
+	palSetPadMode(GPIOA, 7, PAL_MODE_INPUT);
+
+#if 0
+	/* Configure K1/2 Buttons as Input */
+	palSetPadMode(GPIOB, 8, PAL_MODE_INPUT); /* K1 Button */
+	palSetPadMode(GPIOB, 9, PAL_MODE_INPUT); /* K2 Button */
+
+	/* Configure D1/2/3/4 LEDs as Input */
+	palSetPadMode(GPIOB, 0, PAL_MODE_INPUT);
+	palSetPadMode(GPIOB, 3, PAL_MODE_INPUT);
+	palSetPadMode(GPIOB, 4, PAL_MODE_INPUT);
+	palSetPadMode(GPIOB, 5, PAL_MODE_INPUT);
+#endif
+	st25r3916_irq_fn = NULL;
+}
+
+static void bbio_mode_id(t_hydra_console *con)
+{
+	cprint(con, BBIO_HYDRANFC_CARD_EMULATOR, 4);
+}
+
+/* Main command management function */
+static uint16_t processCmd(uint8_t *cmdData, uint16_t  cmdDatalen, uint8_t *rspData)
+{
+	uint16_t rspDataLen;
+
+	cprint(g_con, (char*)&cmdDatalen, 2);
+	cprint(g_con, (char *) cmdData, cmdDatalen);
+
+	chnRead(g_con->sdu, &rspDataLen, 2);
+	chnRead(g_con->sdu, rspData, rspDataLen);
+
+	return rspDataLen*8;
+}
+
+void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
+{
+	uint8_t bbio_subcommand;
+
+	init_gpio_spi_nfc(con);
+
+	bbio_mode_id(con);
+
+	while (!hydrabus_ubtn()) {
+
+		if (chnRead(con->sdu, &bbio_subcommand, 1) == 1) {
+			switch (bbio_subcommand) {
+				case BBIO_NFC_CE_START_EMULATION:
+					/* Init st25r3916 IRQ function callback */
+					st25r3916_irq_fn = st25r3916Isr;
+
+					memset(&user_tag_properties, 0, sizeof(user_tag_properties));
+
+					user_tag_properties.uid[0] = 0xAA;
+					user_tag_properties.uid[1] = 0xBB;
+					user_tag_properties.uid[2] = 0xCC;
+					user_tag_properties.uid[3] = 0xDD;
+					user_tag_properties.uid_len = 4;
+
+					user_tag_properties.sak[0] = 0x20;
+					user_tag_properties.sak_len = 1;
+
+					user_tag_properties.level4_enabled = true;
+
+					hydranfc_ce_set_processCmd_ptr(&processCmd);
+					g_con = con;
+					hydranfc_ce_common(con);
+
+					irq_count = 0;
+					st25r3916_irq_fn = NULL;
+					break;
+
+			case BBIO_RESET: {
+				deinit_gpio_spi_nfc(con);
+				return;
+			}
+			}
+		}
+	}
+}

--- a/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
+++ b/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
@@ -22,6 +22,7 @@
 #include "hydranfc_v2_nfc_mode.h"
 #include "rfal_rf.h"
 #include "hydrabus_bbio.h"
+#include "bsp_gpio.h"
 #include "hydranfc_v2_bbio_card_emulator.h"
 #include "hydranfc_v2_ce.h"
 #include "st25r3916.h"
@@ -115,15 +116,15 @@ static bool init_gpio_spi_nfc(t_hydra_console *con)
 	 */
 	/* spiStart() is done in sniffer see sniffer.c */
 	/* HydraBus SPI1 Slave CLK input */
-	palSetPadMode(GPIOA, 5, PAL_MODE_ALTERNATE(5) | PAL_STM32_OSPEED_MID1);
+	bsp_gpio_init(BSP_GPIO_PORTA, 5, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL);
 	/* HydraBus SPI1 Slave MISO. Not used/Not connected */
-	palSetPadMode(GPIOA, 6, PAL_MODE_ALTERNATE(5) | PAL_STM32_OSPEED_MID1);
+	bsp_gpio_init(BSP_GPIO_PORTA, 6, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL);
 	/* HydraBus SPI1 Slave MOSI. connected to ST25R3916 MOD Pin */
-	palSetPadMode(GPIOA, 7, PAL_MODE_ALTERNATE(5) | PAL_STM32_OSPEED_MID1);
+	bsp_gpio_init(BSP_GPIO_PORTA, 7, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL);
 
 	/* Configure K1/2 Buttons as Input */
-	palSetPadMode(GPIOB, 8, PAL_MODE_INPUT); /* K1 Button */
-	palSetPadMode(GPIOB, 9, PAL_MODE_INPUT); /* K2 Button */
+	bsp_gpio_init(BSP_GPIO_PORTB, 8, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL); /* K1 Button */
+	bsp_gpio_init(BSP_GPIO_PORTB, 9, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL); /* K2 Button */
 
 	/* Configure D1/2/3/4 LEDs as Output */
 	D1_OFF;
@@ -131,15 +132,16 @@ static bool init_gpio_spi_nfc(t_hydra_console *con)
 	D3_OFF;
 	D4_OFF;
 
-	palSetPadMode(GPIOB, 0, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+	/* LED_D1 or TST_PÏN */
+	bsp_gpio_init(BSP_GPIO_PORTB, 0, MODE_CONFIG_DEV_GPIO_OUT_PUSHPULL, MODE_CONFIG_DEV_GPIO_NOPULL);
 
 #ifndef MAKE_DEBUG
 	// can't use LED on PB3 if using SWO
-	palSetPadMode(GPIOB, 3, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+	bsp_gpio_init(BSP_GPIO_PORTB, 3, MODE_CONFIG_DEV_GPIO_OUT_PUSHPULL, MODE_CONFIG_DEV_GPIO_NOPULL);
 #endif
 
-	palSetPadMode(GPIOB, 4, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
-	palSetPadMode(GPIOB, 5, PAL_MODE_OUTPUT_PUSHPULL | PAL_STM32_OSPEED_MID1);
+	bsp_gpio_init(BSP_GPIO_PORTB, 4, MODE_CONFIG_DEV_GPIO_OUT_PUSHPULL, MODE_CONFIG_DEV_GPIO_NOPULL);
+	bsp_gpio_init(BSP_GPIO_PORTB, 5, MODE_CONFIG_DEV_GPIO_OUT_PUSHPULL, MODE_CONFIG_DEV_GPIO_NOPULL);
 
 	palDisablePadEvent(GPIOA, 1);
 	/* ST25R3916 IRQ output / HydraBus PA1 input */
@@ -153,7 +155,8 @@ static bool init_gpio_spi_nfc(t_hydra_console *con)
 	/* Init st25r3916 IRQ function callback */
 	st25r3916_irq_fn = st25r3916Isr;
 	hal_st25r3916_spiInit(ST25R391X_SPI_DEVICE);
-	if (hydranfc_v2_init_RFAL(con) != ERR_NONE) {
+	if (hydranfc_v2_init_RFAL(con) != ERR_NONE)
+	{
 		cprintf(con, "HydraNFC v2 not found.\r\n");
 		return FALSE;
 	}
@@ -169,21 +172,10 @@ static void deinit_gpio_spi_nfc(t_hydra_console *con)
 
 	bsp_spi_deinit(BSP_DEV_SPI2);
 
-	palSetPadMode(GPIOA, 5, PAL_MODE_INPUT);
-	palSetPadMode(GPIOA, 6, PAL_MODE_INPUT);
-	palSetPadMode(GPIOA, 7, PAL_MODE_INPUT);
+	bsp_gpio_init(BSP_GPIO_PORTA, 5, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL);
+	bsp_gpio_init(BSP_GPIO_PORTA, 6, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL);
+	bsp_gpio_init(BSP_GPIO_PORTA, 7, MODE_CONFIG_DEV_GPIO_IN, MODE_CONFIG_DEV_GPIO_NOPULL);
 
-#if 0
-	/* Configure K1/2 Buttons as Input */
-	palSetPadMode(GPIOB, 8, PAL_MODE_INPUT); /* K1 Button */
-	palSetPadMode(GPIOB, 9, PAL_MODE_INPUT); /* K2 Button */
-
-	/* Configure D1/2/3/4 LEDs as Input */
-	palSetPadMode(GPIOB, 0, PAL_MODE_INPUT);
-	palSetPadMode(GPIOB, 3, PAL_MODE_INPUT);
-	palSetPadMode(GPIOB, 4, PAL_MODE_INPUT);
-	palSetPadMode(GPIOB, 5, PAL_MODE_INPUT);
-#endif
 	st25r3916_irq_fn = NULL;
 }
 

--- a/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.h
+++ b/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.h
@@ -1,0 +1,25 @@
+/*
+ * HydraBus/HydraNFC v2
+ *
+ * Copyright (C) 2020 Guillaume VINET
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _HYDRANFC_V2_BBIO_CARD_EMULATOR_H_
+#define _HYDRANFC_V2_BBIO_CARD_EMULATOR_H_
+
+#define BBIO_HYDRANFC_CARD_EMULATOR    "NCE2"
+
+void bbio_mode_hydranfc_v2_card_emulator (t_hydra_console *con);
+
+#endif /* _HYDRANFC_V2_BBIO_CARD_EMULATOR_H_ */


### PR DESCRIPTION
# BBIO Card Emulator ISO 14443 A

Update the card emulation from AAsyunkin-se to add a BBIO  mode at the APDU level. You get the APDU command and choose the answer with a python script. The customization of some parameters as UID will be added later.

Example given in  contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py.
```python
import serial

port = "/dev/ttyACM2"

ser = serial.Serial(port, timeout=None)


# We enter BBIO1 MODE
def enter_bbio(ser):
    ser.timeout = 0.01
    for _ in range(20):
        ser.write(b"\x00")
        if b"BBIO1" in ser.read(5):
            ser.reset_input_buffer()
            ser.timeout = None

            # We enter reader mode
            ser.write(b"\x17")
            if ser.read(4) != b"NCE2":
                raise Exception("Cannot enter BBIO Reader mode")
            return
    raise Exception("Cannot enter BBIO mode.")


enter_bbio(ser)

print("Card emulator")
ser.write(b"\x01")

print("Cmd")
print(ser.read(40).hex())

while 1:
    cmd_len = int.from_bytes(ser.read(2), byteorder="little")
    print(f"Len: {cmd_len}")
    cmd = ser.read(cmd_len)
    print(f"Cmd {cmd.hex()}")

    resp = bytes.fromhex("CAFEBABE9000")
    resp_len = len(resp)
    ser.write(resp_len.to_bytes(2, byteorder="little"))
    ser.write(resp)
```

Tested with an hydra NFC v1 with this script

```python
import time
from pynfcreader.devices.hydra_nfc import HydraNFC
from pynfcreader.sessions.iso14443.iso14443a import Iso14443ASession

hydra_nfc = HydraNFC(port="/dev/ttyACM1", debug=False)
hn = Iso14443ASession(drv=hydra_nfc, block_size=120)

hn.connect()
hn.field_off()
time.sleep(0.1)
hn.field_on()
hn.polling()
hn.send_apdu("00 a4 04 00   0E   32 50 41 59 2E 53 59 53 2E 44 44 46 30 31 00")
hn.field_off()
```

We got this output:
```
INFO  ::  Connect to HydraNFC
INFO  ::  
INFO  ::  field off
INFO  ::  field on
INFO  ::  REQA (7 bits):
INFO  ::  	26                                                     &   
INFO  ::  ATQA:
INFO  ::  	04 00                                                  ..   
INFO  ::  Select cascade level 1:
INFO  ::  	93 20                                                  .    
INFO  ::  Select cascade level 1 response:
INFO  ::  	AA BB CC DD 00                                         .....   
INFO  ::  Select cascade level 1:
INFO  ::  	93 70 AA BB CC DD 00                                   .p.....   
INFO  ::  Select cascade level 1 response:
INFO  ::  	20 FC 70                                                .p   
INFO  ::  Request for Answer To Select (RATS):
INFO  ::  	PCD selected options:
INFO  ::  		FSDI : 0x0 => max PCD frame size : 16 bytes
INFO  ::  		CID  : 0x0
INFO  ::  RATS
INFO  ::  	E0 00                                                  ..   
INFO  ::  Answer to Select (ATS = RATS response):
INFO  ::  	07 78 00 80 00 73 74 07   66                           .x...st.   f
INFO  ::  	T0 : 0x78
INFO  ::  		FlSCI : 0x8 => max card frame size : 256 bytes
INFO  ::  		TA(1) present
INFO  ::  		TB(1) present
INFO  ::  		TC(1) present
INFO  ::  	TB(1) : 0x80
INFO  ::  		Interpretation : TODO...
INFO  ::  	Historical bytes : 73 74
INFO  ::  	CRC : 07 66
INFO  ::  
INFO  ::  
INFO  ::  
INFO  ::  PPS
INFO  ::  	PCD selected options:
INFO  ::  	CID : 0x0
INFO  ::  	PPS1 not transmitted
INFO  ::  PPS:
INFO  ::  	D0 01                                                  ..   
INFO  ::  PPS response:
INFO  ::  	D0 73 87                                               .s.   
INFO  ::  	PPS accepted
INFO  ::  
INFO  ::  APDU command:
INFO  ::  	00 A4 04 00 0E 32 50 41   59 2E 53 59 53 2E 44 44      .....2PA   Y.SYS.DD
INFO  ::  	46 30 31 00                                            F01.   
INFO  ::  		TPDU command:
INFO  ::  		0A 00 00 A4 04 00 0E 32   50 41 59 2E 53 59 53 2E      .......2   PAY.SYS.
INFO  ::  		44 44 46 30 31 00                                      DDF01.   
INFO  ::  		TPDU response:
INFO  ::  		0A 00 CA FE BA BE 90 00   BC 9D                        ........   ..
INFO  ::  APDU response:
INFO  ::  	CA FE BA BE 90 00                                      ......   
INFO  ::  field off
```