### PR TITLE
feature: bbio card emulation - uid/sak customization

### DIFF
--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
@@ -8,7 +8,7 @@
 #
 import serial
 
-port = "/dev/ttyACM2"
+port = "/dev/ttyACM1"
 
 ser = serial.Serial(port, timeout=None)
 
@@ -32,11 +32,25 @@ def enter_bbio(ser):
 
 enter_bbio(ser)
 
-print("Card emulator")
+
+uid = bytes.fromhex("DEADBEEF")
+print(f"Set UID to {uid.hex()}")
+ser.write(b"\04" + b"\04" + uid)
+resp = ser.read(1)
+assert resp[0] == 0x01
+
+sak = b"\x21"
+print(f"Set SAK to {sak.hex()}")
+ser.write(b"\05" + b"\01" + sak)
+resp = ser.read(1)
+assert resp[0] == 0x01
+
+print("Start Card emulation")
 ser.write(b"\x01")
 
-print("Cmd")
+print("Get banner")
 print(ser.read(40).hex())
+
 
 while 1:
     cmd_len = int.from_bytes(ser.read(2), byteorder="little")

--- a/src/hydrabus/hydrabus_bbio.h
+++ b/src/hydrabus/hydrabus_bbio.h
@@ -198,5 +198,7 @@
 
 #define BBIO_NFC_CE_START_EMULATION    0b00000001
 #define BBIO_NFC_CE_GET_RX             0b00000011
+#define BBIO_NFC_CE_SET_UID            0b00000100
+#define BBIO_NFC_CE_SET_SAK            0b00000101
 
 int cmd_bbio(t_hydra_console *con);

--- a/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
+++ b/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
@@ -183,6 +183,19 @@ static void bbio_mode_id(t_hydra_console *con)
 	cprint(con, BBIO_HYDRANFC_CARD_EMULATOR, 4);
 }
 
+static void init(){
+	memset(&user_tag_properties, 0, sizeof(user_tag_properties));
+
+	user_tag_properties.uid[0] = 0xAA;
+	user_tag_properties.uid[1] = 0xBB;
+	user_tag_properties.uid[2] = 0xCC;
+	user_tag_properties.uid[3] = 0xDD;
+	user_tag_properties.uid_len = 4;
+
+	user_tag_properties.sak[0] = 0x20;
+	user_tag_properties.sak_len = 1;
+}
+
 /* Main command management function */
 static uint16_t processCmd(uint8_t *cmdData, uint16_t  cmdDatalen, uint8_t *rspData)
 {
@@ -199,11 +212,13 @@ static uint16_t processCmd(uint8_t *cmdData, uint16_t  cmdDatalen, uint8_t *rspD
 
 void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 {
-	uint8_t bbio_subcommand;
+	uint8_t bbio_subcommand, clen, rlen;
+	uint8_t *rx_data = (uint8_t *) g_sbuf + 4096;
 
 	init_gpio_spi_nfc(con);
 
 	bbio_mode_id(con);
+	init();
 
 	while (!hydrabus_ubtn()) {
 
@@ -212,17 +227,6 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 			case BBIO_NFC_CE_START_EMULATION:
 				/* Init st25r3916 IRQ function callback */
 				st25r3916_irq_fn = st25r3916Isr;
-
-				memset(&user_tag_properties, 0, sizeof(user_tag_properties));
-
-				user_tag_properties.uid[0] = 0xAA;
-				user_tag_properties.uid[1] = 0xBB;
-				user_tag_properties.uid[2] = 0xCC;
-				user_tag_properties.uid[3] = 0xDD;
-				user_tag_properties.uid_len = 4;
-
-				user_tag_properties.sak[0] = 0x20;
-				user_tag_properties.sak_len = 1;
 
 				user_tag_properties.level4_enabled = true;
 
@@ -233,6 +237,37 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 				irq_count = 0;
 				st25r3916_irq_fn = NULL;
 				break;
+
+			case BBIO_NFC_CE_SET_UID:{
+				chnRead(con->sdu, &clen, 1);
+				chnRead(con->sdu, rx_data, clen);
+
+				switch (clen){
+					case 4:
+					case 7:
+						user_tag_properties.uid_len = clen;
+						memcpy(user_tag_properties.uid, rx_data, clen);
+						rx_data[0] = 0x01;
+						break;
+					default:
+						rx_data[0] = 0x00;
+				}
+
+				cprint(con, (char *) rx_data, 1);
+				break;
+			}
+
+			case BBIO_NFC_CE_SET_SAK:{
+				chnRead(con->sdu, &clen, 1);
+				chnRead(con->sdu, rx_data, clen);
+
+				user_tag_properties.sak[0] = rx_data[0];
+
+				rx_data[0] = 1;
+
+				cprint(con, (char *) rx_data, 1);
+				break;
+			}
 
 			case BBIO_RESET: {
 				deinit_gpio_spi_nfc(con);


### PR DESCRIPTION
# UID/SAK customization

Two commands added in python script example
```python
#!/usr/bin/env python3
#
# Low level script to show how to emulate an ISO 14443-A card
# You shall use https://github.com/hydrabus/pyHydrabus or https://github.com/gvinet/pynfcreader to have a user-friendly high level API
#
# Author: Guillaume VINET <guillaume.vinet@gmail.com>
# License: GPLv3 (https://choosealicense.com/licenses/gpl-3.0/)
#
import serial

port = "/dev/ttyACM1"

ser = serial.Serial(port, timeout=None)


# We enter BBIO1 MODE
def enter_bbio(ser):
    ser.timeout = 0.01
    for _ in range(20):
        ser.write(b"\x00")
        if b"BBIO1" in ser.read(5):
            ser.reset_input_buffer()
            ser.timeout = None

            # We enter reader mode
            ser.write(b"\x17")
            if ser.read(4) != b"NCE2":
                raise Exception("Cannot enter BBIO Card Emulator mode")
            return
    raise Exception("Cannot enter BBIO mode.")


enter_bbio(ser)


uid = bytes.fromhex("DEADBEEF")
print(f"Set UID to {uid.hex()}")
ser.write(b"\04" + b"\04" + uid)
resp = ser.read(1)
assert resp[0] == 0x01

sak = b"\x21"
print(f"Set SAK to {sak.hex()}")
ser.write(b"\05" + b"\01" + sak)
resp = ser.read(1)
assert resp[0] == 0x01

print("Start Card emulation")
ser.write(b"\x01")

print("Get banner")
print(ser.read(40).hex())


while 1:
    cmd_len = int.from_bytes(ser.read(2), byteorder="little")
    print(f"Len: {cmd_len}")
    cmd = ser.read(cmd_len)
    print(f"Cmd {cmd.hex()}")

    resp = bytes.fromhex("CAFEBABE9000")
    resp_len = len(resp)
    ser.write(resp_len.to_bytes(2, byteorder="little"))
    ser.write(resp)
```