### PR TITLE
features-bbio_card_emulation-card_activation_detection

### DIFF
--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
@@ -48,17 +48,33 @@ assert resp[0] == 0x01
 print("Start Card emulation")
 ser.write(b"\x01")
 
-print("Get banner")
-print(ser.read(40).hex())
-
+BBIO_NFC_CE_CARD_ACTIVATION = 7
+BBIO_NFC_CE_CARD_CMD = 8
+BBIO_NFC_CE_END_EMULATION = 9
 
 while 1:
-    cmd_len = int.from_bytes(ser.read(2), byteorder="little")
-    print(f"Len: {cmd_len}")
-    cmd = ser.read(cmd_len)
-    print(f"Cmd {cmd.hex()}")
+    # We get the command tag
+    cmd_tag = int.from_bytes(ser.read(1), byteorder="little")
+    # print(f"Tag: {cmd_tag:02X}")
 
-    resp = bytes.fromhex("CAFEBABE9000")
-    resp_len = len(resp)
-    ser.write(resp_len.to_bytes(2, byteorder="little"))
-    ser.write(resp)
+    if cmd_tag == BBIO_NFC_CE_END_EMULATION:
+        print("Emulation stopped")
+        break
+    elif cmd_tag == BBIO_NFC_CE_CARD_ACTIVATION:
+        # A card was activated
+        print("Card activated")
+    elif cmd_tag == BBIO_NFC_CE_CARD_CMD:
+
+        # We get data length
+        cmd_len = int.from_bytes(ser.read(2), byteorder="little")
+        print(f"Len: {cmd_len}")
+
+        # We get data
+        cmd = ser.read(cmd_len)
+        print(f"Cmd {cmd.hex()}")
+
+        # We build the response
+        resp = bytes.fromhex("CAFEBABE9000")
+        resp_len = len(resp)
+        ser.write(resp_len.to_bytes(2, byteorder="little"))
+        ser.write(resp)

--- a/src/hydrabus/hydrabus_bbio.h
+++ b/src/hydrabus/hydrabus_bbio.h
@@ -200,5 +200,8 @@
 #define BBIO_NFC_CE_GET_RX             0b00000011
 #define BBIO_NFC_CE_SET_UID            0b00000100
 #define BBIO_NFC_CE_SET_SAK            0b00000101
+#define BBIO_NFC_CE_CARD_ACTIVATION    0b00000111
+#define BBIO_NFC_CE_CARD_CMD           0b00001000
+#define BBIO_NFC_CE_END_EMULATION      0b00001001
 
 int cmd_bbio(t_hydra_console *con);

--- a/src/hydranfc_v2/ce.c
+++ b/src/hydranfc_v2/ce.c
@@ -67,6 +67,14 @@ rfalLmState statePrev = RFAL_LM_STATE_NOT_INIT;
 rfalTransceiveState     tStateCur = 3;
 rfalTransceiveState     tStatePrev = 3;
 
+uint16_t (*cardA_activated_ptr)(void) = NULL;
+
+void ce_set_cardA_activated_ptr(void * ptr)
+{
+	cardA_activated_ptr = ptr;
+}
+
+
 void ceInitalize( void )
 {
 	transceiveCtx.txBuf = txBuf_ce;
@@ -234,6 +242,9 @@ void ceHandler( void )
 
 				case ERR_NONE:
 					isActivatedA = true;
+					if(cardA_activated_ptr != NULL) {
+						cardA_activated_ptr();
+					}
 					break;
 
 				// all other error cases are simple ignored ..

--- a/src/hydranfc_v2/hydranfc_v2_ce.c
+++ b/src/hydranfc_v2/hydranfc_v2_ce.c
@@ -288,7 +288,7 @@ void dispatcherInterruptHandler()
 	}
 }
 
-static void ceRun(t_hydra_console *con)
+static void ceRun(t_hydra_console *con, bool quiet)
 {
 	ReturnCode err = ERR_NONE;
 	uint16_t dataSize;
@@ -317,8 +317,11 @@ static void ceRun(t_hydra_console *con)
 		dataSize = (*current_processCmdPtr)(rxtxFrameBuf, dataSize, rxtxFrameBuf);
 		err = ceSetTx(CARDEMULATION_CMD_SET_TX_A,rxtxFrameBuf, dataSize);
 
-		if(err != ERR_NONE)
-			cprintf(con, "ceSetTx err %d\r\n", err);
+		if(err != ERR_NONE) {
+			if( quiet != TRUE) {
+				cprintf(con, "ceSetTx err %d\r\n", err);
+			}
+		}
 		printf_dbg("ceSetTx err %d\r\n", err);
 		// dataSize in bits after processCmd()
 		dataSize = rfalConvBitsToBytes(dataSize);
@@ -336,7 +339,7 @@ static void ceRun(t_hydra_console *con)
 		case ERR_LINK_LOSS:
 			break;
 		default:
-			cprintf(con, "ceGetRx err %d\r\n", err);
+			if( quiet != TRUE) { cprintf(con, "ceGetRx err %d\r\n", err); }
 			printf_dbg("ceGetRx err %d\r\n", err);
 			break;
 		}
@@ -349,7 +352,7 @@ void hydranfc_ce_set_processCmd_ptr(void * ptr)
 }
 
 
-void hydranfc_ce_common(t_hydra_console *con)
+void hydranfc_ce_common(t_hydra_console *con, bool quiet)
 {
 	uint16_t length = 0;
 	ReturnCode err = ERR_NONE;
@@ -403,18 +406,24 @@ void hydranfc_ce_common(t_hydra_console *con)
 
 	err = ceStart(startCmd, sizeof(startCmd));
 	if (err == ERR_NONE) {
-		cprintf(con, "CE started. Press user button to stop.\r\n");
+		if( quiet != TRUE) {
+			cprintf(con, "CE started. Press user button to stop.\r\n");
+		}
 
 		while (!hydrabus_ubtn()) {
-			ceRun(con);
+			ceRun(con, quiet);
 			chThdYield();
 			//		  chThdSleepMilliseconds(50);
 		}
 
 		ceStop();
-		cprintf(con, "CE finished\r\n");
+		if (quiet != TRUE) {
+			cprintf(con, "CE finished\r\n");
+		}
 	} else {
-		cprintf(con, "CE failed: %d\r\n", err);
+		if (quiet != TRUE) {
+			cprintf(con, "CE failed: %d\r\n", err);
+		}
 	}
 }
 

--- a/src/hydranfc_v2/hydranfc_v2_ce.h
+++ b/src/hydranfc_v2/hydranfc_v2_ce.h
@@ -37,7 +37,7 @@ typedef struct {
 
 extern sUserTagProperties user_tag_properties;
 
-void hydranfc_ce_common(t_hydra_console *con);
+void hydranfc_ce_common(t_hydra_console *con, bool quiet);
 
 #endif
 

--- a/src/hydranfc_v2/hydranfc_v2_nfc_mode.c
+++ b/src/hydranfc_v2/hydranfc_v2_nfc_mode.c
@@ -53,7 +53,7 @@
 #include "hydranfc_v2_ce.h"
 #include "hydranfc_v2_reader.h"
 
-extern void hydranfc_ce_common(t_hydra_console *con);
+extern void hydranfc_ce_common(t_hydra_console *con, bool quiet);
 extern uint32_t user_uid_len;
 extern uint8_t user_uid[8];
 extern uint8_t user_sak;
@@ -862,7 +862,7 @@ static void hydranfc_card_emul_iso14443a(t_hydra_console *con)
 	/* Init st25r3916 IRQ function callback */
 	st25r3916_irq_fn = st25r3916Isr;
 
-	hydranfc_ce_common(con);
+	hydranfc_ce_common(con, FALSE);
 
 	irq_count = 0;
 	st25r3916_irq_fn = NULL;


### PR DESCRIPTION
# BBIO Card Emulation ISO 14443 Enhancement

* Once the PPS exchange was successfully done, we send a BBIO_NFC_CE_CARD_ACTIVATION event to indicate a card was detected.
* We detect when the user button is pressed to stop the card emulation and send the BBIO_NFC_CE_END_EMULATION.
* When the BBIO card emulation is used, we stop the display of information message. We keep displaying them when the emulation is used with the NFC menu.

bbio_hydranfc_card_emulator_iso_14443_a_example.py script was updated.