### PR TITLE
feat-bbio-card-emulation-iso-14443-a-raw-mode

### DIFF
--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_raw_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_raw_example.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Low level script to show how to emulate an ISO 14443-A card
+# You shall use https://github.com/hydrabus/pyHydrabus or https://github.com/gvinet/pynfcreader to have a user-friendly high level API
+#
+# Author: Guillaume VINET <guillaume.vinet@gmail.com>
+# License: GPLv3 (https://choosealicense.com/licenses/gpl-3.0/)
+#
+import serial
+
+port = "/dev/ttyACM2"
+
+ser = serial.Serial(port, timeout=None)
+
+
+# We enter BBIO1 MODE
+def enter_bbio(ser):
+    ser.timeout = 0.01
+    for _ in range(20):
+        ser.write(b"\x00")
+        if b"BBIO1" in ser.read(5):
+            ser.reset_input_buffer()
+            ser.timeout = None
+
+            # We enter reader mode
+            ser.write(b"\x17")
+            if ser.read(4) != b"NCE2":
+                raise Exception("Cannot enter BBIO Card Emulator mode")
+            return
+    raise Exception("Cannot enter BBIO mode.")
+
+
+enter_bbio(ser)
+
+
+uid = bytes.fromhex("DEADBEEF")
+print(f"Set UID to {uid.hex()}")
+ser.write(b"\04" + b"\04" + uid)
+resp = ser.read(1)
+assert resp[0] == 0x01
+
+sak = b"\x21"
+print(f"Set SAK to {sak.hex()}")
+ser.write(b"\05" + b"\01" + sak)
+resp = ser.read(1)
+assert resp[0] == 0x01
+
+print("Start Card emulation")
+ser.write(b"\x0A")
+
+BBIO_NFC_CE_CARD_ACTIVATION = 7
+BBIO_NFC_CE_CARD_CMD = 8
+BBIO_NFC_CE_END_EMULATION = 9
+
+while 1:
+    # We get the command tag
+    cmd_tag = int.from_bytes(ser.read(1), byteorder="little")
+    # print(f"Tag: {cmd_tag:02X}")
+
+    if cmd_tag == BBIO_NFC_CE_END_EMULATION:
+        print("Emulation stopped")
+        break
+    elif cmd_tag == BBIO_NFC_CE_CARD_ACTIVATION:
+        # A card was activated
+        print("Card activated")
+    elif cmd_tag == BBIO_NFC_CE_CARD_CMD:
+
+        # We get data length
+        cmd_len = int.from_bytes(ser.read(2), byteorder="little")
+        print(f"Len: {cmd_len}")
+
+        # We get data
+        cmd = ser.read(cmd_len)
+        print(f"Cmd {cmd.hex()}")
+
+        # We build the response
+        resp = bytes.fromhex("CAFEBABE9000")
+        resp_len = len(resp)
+        ser.write(resp_len.to_bytes(2, byteorder="little"))
+        ser.write(resp)

--- a/src/hydrabus/hydrabus_bbio.h
+++ b/src/hydrabus/hydrabus_bbio.h
@@ -203,5 +203,6 @@
 #define BBIO_NFC_CE_CARD_ACTIVATION    0b00000111
 #define BBIO_NFC_CE_CARD_CMD           0b00001000
 #define BBIO_NFC_CE_END_EMULATION      0b00001001
+#define BBIO_NFC_CE_START_EMULATION_RAW 0b00001010
 
 int cmd_bbio(t_hydra_console *con);

--- a/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
+++ b/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
@@ -41,101 +41,66 @@
 #include "bsp_print_dbg.h"
 #include <string.h>
 
-typedef enum {
-	T4T_MODE_NOT_SET = 0,
-	T4T_MODE_URI,
-	T4T_MODE_EMAIL
-} eT4TEmulationMode;
-
-enum cardEmulationMode {
-	CARDEMULATION_MODE_NDEF                     = 0x01,
-	CARDEMULATION_MODE_REFLECT                  = 0x02,
-	CARDEMULATION_PROCESS_INTERNAL              = 0x80,
-};
-
 enum cardEmulationCommand {
-	CARDEMULATION_CMD_START                     = 0x01, /*!< start listen mode. */
-	CARDEMULATION_CMD_STOP                      = 0x02, /*!< stop listen mode. */
+	CARDEMULATION_CMD_START = 0x01, /*!< start listen mode. */
+	CARDEMULATION_CMD_STOP = 0x02, /*!< stop listen mode. */
 
-	CARDEMULATION_CMD_GET_RX_A                  = 0x11,
-	CARDEMULATION_CMD_SET_TX_A                  = 0x12,
-	CARDEMULATION_CMD_GET_RX_B                  = 0x13,
-	CARDEMULATION_CMD_SET_TX_B                  = 0x14,
-	CARDEMULATION_CMD_GET_RX_F                  = 0x15,
-	CARDEMULATION_CMD_SET_TX_F                  = 0x16,
+	CARDEMULATION_CMD_GET_RX_A = 0x11,
+	CARDEMULATION_CMD_SET_TX_A = 0x12,
+	CARDEMULATION_CMD_GET_RX_B = 0x13,
+	CARDEMULATION_CMD_SET_TX_B = 0x14,
+	CARDEMULATION_CMD_GET_RX_F = 0x15,
+	CARDEMULATION_CMD_SET_TX_F = 0x16,
 
-	CARDEMULATION_CMD_GET_LISTEN_STATE          = 0x21,
+	CARDEMULATION_CMD_GET_LISTEN_STATE = 0x21,
 };
-
-typedef struct {
-	uint32_t uid_len;
-	uint8_t uid[8];
-	uint32_t sak_len; // 0 or 1
-	uint8_t sak[1];
-	uint8_t *uri;
-	bool level4_enabled;
-	eT4TEmulationMode t4tEmulationMode;
-} sUserTagProperties;
-
 
 static volatile int irq_count;
 static volatile int irq;
 static volatile int irq_end_rx;
-static void (* st25r3916_irq_fn)(void) = NULL;
+static void (*st25r3916_irq_fn)(void) = NULL;
+
 #define TX_BUF_LENGTH       (256+3)
 static uint8_t txBuf_ce[TX_BUF_LENGTH] __attribute__ ((section(".cmm")));
 
 #define RX_BUF_LENGTH       (256+3)
 static uint8_t rxBuf_ce[RX_BUF_LENGTH] __attribute__ ((section(".cmm")));
 static uint16_t rxRcvdLen = 0;
-static bool  ceEnabled;
-static sUserTagProperties user_tag_properties;
+static bool ceEnabled;
 static rfalLmState state;
-static rfalLmConfPA                            configA;
-static rfalLmConfPB                            configB;
-static rfalLmConfPF                            configF;
-static rfalIsoDepAtsParam                      atsParam;
-static uint8_t                                 histChar[16];
-static uint32_t                                configMask = 0;
-static rfalTransceiveContext                   transceiveCtx;
+static rfalLmConfPA configA;
+static rfalIsoDepAtsParam atsParam;
+static uint8_t histChar[16];
+static uint32_t configMask = 0;
+static rfalTransceiveContext transceiveCtx;
 
-static uint8_t                                 emuMode = 0;
+static rfalIsoDepBufFormat *rxBufA;
+static rfalIsoDepBufFormat *txBufA;
+static bool bIsRxChaining;
+static bool isActivatedA = false;
+static bool isFirstA3_Frame = true;
+static rfalIsoDepTxRxParam isoDepTxRxParam;
 
-static rfalIsoDepBufFormat                     *rxBufA;
-static rfalIsoDepBufFormat                     *txBufA;
-static bool                                    bIsRxChaining;
-static bool                                    isActivatedA = false;
-static bool                                    isFirstF_Frame = false;
-static bool                                    isFirstA3_Frame = true;
-static rfalIsoDepTxRxParam                     isoDepTxRxParam;
-
-static bool                                    rxReady = false;
-static bool                                    txReady = false;
-
-static rfalLmState statePrev = RFAL_LM_STATE_NOT_INIT;
-static rfalTransceiveState     tStateCur = 3;
-static rfalTransceiveState     tStatePrev = 3;
+static bool rxReady = false;
+static bool txReady = false;
 
 static uint16_t (*cardA_activated_ptr)(void) = NULL;
 
 static uint8_t rxtxFrameBuf[512] __attribute__ ((section(".cmm")));
 
-uint16_t bbio_processCmd(uint8_t *cmdData, uint16_t  cmdDataLen, uint8_t *rspData);
+uint16_t bbio_processCmd(uint8_t *cmdData, uint16_t cmdDataLen, uint8_t *rspData);
 static uint16_t (*current_processCmdPtr)(uint8_t *, uint16_t, uint8_t *) = bbio_processCmd;
-
 
 static uint16_t dispatcherInterruptResults[32];
 
-static sUserTagProperties user_tag_properties;
-
 void hydranfc_ce_common(t_hydra_console *con, bool quiet);
-static const uint8_t dispatcherInterruptResultRegs[32]= {
-	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff, /* 1st byte */
-	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff, /* 2nd byte */
+static const uint8_t dispatcherInterruptResultRegs[32] = {
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* 1st byte */
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* 2nd byte */
 	ST25R3916_REG_CAPACITANCE_MEASURE_RESULT,
 	ST25R3916_REG_PHASE_MEASURE_RESULT,
-	ST25R3916_REG_AMPLITUDE_MEASURE_RESULT,0xff,0xff,0xff,0xff,0xff, /* 3rd byte */
-	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff, /* 4th byte */
+	ST25R3916_REG_AMPLITUDE_MEASURE_RESULT, 0xff, 0xff, 0xff, 0xff, 0xff, /* 3rd byte */
+	0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* 4th byte */
 };
 
 static void dispatcherInterruptHandler(void)
@@ -144,26 +109,25 @@ static void dispatcherInterruptHandler(void)
 	uint8_t val;
 	uint16_t isrs;
 
-	for (i=0; i<32; i++) { /* !!!!!!!!!!!!!!!!! */
-		if(dispatcherInterruptResultRegs[i] >= 0x40) continue;
-		if(!st25r3916GetInterrupt(1UL<<i)) continue;
+	for (i = 0; i < 32; i++) { /* !!!!!!!!!!!!!!!!! */
+		if (dispatcherInterruptResultRegs[i] >= 0x40) continue;
+		if (!st25r3916GetInterrupt(1UL << i)) continue;
 
 		isrs = dispatcherInterruptResults[i] >> 8;
 		if (isrs < 255) isrs++;
 
 		st25r3916ReadRegister(dispatcherInterruptResultRegs[i], &val);
 
-		dispatcherInterruptResults[i] = (isrs<<8) | val;
+		dispatcherInterruptResults[i] = (isrs << 8)|val;
 	}
 }
-
 
 static ReturnCode ceGetRx(const uint8_t cmd, uint8_t *txData, uint16_t *txSize)
 {
 	ReturnCode err = ERR_NOTFOUND;
 	switch (cmd) {
 	case CARDEMULATION_CMD_GET_RX_A:
-		if(isActivatedA) {
+		if (isActivatedA) {
 			//err = rfalIsoDepGetTransceiveStatus();
 			err = rfalIsoDepGetTransceiveStatusRawMode();
 
@@ -173,7 +137,13 @@ static ReturnCode ceGetRx(const uint8_t cmd, uint8_t *txData, uint16_t *txSize)
 			case ERR_LINK_LOSS:
 			default:
 				rfalListenStop();
-				rfalListenStart(configMask, &configA, &configB, &configF, rxBuf_ce, rfalConvBytesToBits(RX_BUF_LENGTH), &rxRcvdLen);
+				rfalListenStart(configMask,
+				                &configA,
+				                NULL,
+				                NULL,
+				                rxBuf_ce,
+				                rfalConvBytesToBits(RX_BUF_LENGTH),
+				                &rxRcvdLen);
 				rxReady = txReady = isActivatedA = false;
 				isFirstA3_Frame = true;
 				printf_dbg("LLoss3 %d\r\n", err);
@@ -196,7 +166,7 @@ static ReturnCode ceGetRx(const uint8_t cmd, uint8_t *txData, uint16_t *txSize)
 
 		} else {
 			// handle layer3 comms here
-			if(isFirstA3_Frame) {
+			if (isFirstA3_Frame) {
 				// IMPORTANT: We can not call rfalGetTransceiveStatus before we did the first
 				// call rfalStartTransceive
 
@@ -228,21 +198,21 @@ static ReturnCode ceGetRx(const uint8_t cmd, uint8_t *txData, uint16_t *txSize)
 	return err;
 }
 
-static ReturnCode ceSetTx(const uint8_t cmd, const uint8_t * rxData, const uint16_t rxSize)
+static ReturnCode ceSetTx(const uint8_t cmd, const uint8_t *rxData, const uint16_t rxSize)
 {
 	ReturnCode err = ERR_NOTFOUND;
 	uint16_t rxSizeBytes = rfalConvBitsToBytes(rxSize);
 
 	switch (cmd) {
 	case CARDEMULATION_CMD_SET_TX_A:
-		if(isActivatedA) {
+		if (isActivatedA) {
 			if (txReady) {
 				ST_MEMCPY(isoDepTxRxParam.txBuf->inf, rxData, rxSizeBytes);
 				isoDepTxRxParam.txBufLen = rxSizeBytes;
 				*isoDepTxRxParam.rxLen = 0;
 				err = rfalIsoDepStartTransceive(isoDepTxRxParam);
 
-				if(err == ERR_NONE) {
+				if (err == ERR_NONE) {
 					rxReady = txReady = false;
 				}
 			}
@@ -255,30 +225,16 @@ static ReturnCode ceSetTx(const uint8_t cmd, const uint8_t * rxData, const uint1
 	return err;
 }
 
-
-
-static void ceHandler( void )
+static void ceHandler(void)
 {
 	bool dataFlag = false;
 
 	/* Check whether CE is enabled */
-	if( !ceEnabled ) {
+	if (!ceEnabled) {
 		return;
 	}
 
 	state = rfalListenGetState(&dataFlag, NULL);
-	if (state != statePrev) {
-		// new state
-		printf_dbg("rLGS %d\r\n", state);
-		statePrev = state;
-	}
-	tStateCur = rfalGetTransceiveState( );
-	if (tStateCur != tStatePrev) {
-		// new state
-		printf_dbg("rGTS %d\r\n", tStateCur);
-		tStatePrev = tStateCur;
-	}
-
 
 	switch (state) {
 	// ------------------------------------------------------------------
@@ -287,53 +243,32 @@ static void ceHandler( void )
 	//
 	case RFAL_LM_STATE_ACTIVE_A:
 	case RFAL_LM_STATE_ACTIVE_Ax: {
-		if(dataFlag == true) {
+		if (dataFlag == true) {
 			if (rfalIsoDepIsRats(rxBuf_ce, rfalConvBitsToBytes(rxRcvdLen))) {
-				if (user_tag_properties.level4_enabled) {
-					printf_dbg("RATS!\r\n");
+				printf_dbg("RATS!\r\n");
 
-					// enter next already state
-					rfalListenSetState(RFAL_LM_STATE_CARDEMU_4A);
+				// enter next already state
+				rfalListenSetState(RFAL_LM_STATE_CARDEMU_4A);
 
-					// prepare for RATS
-					rfalIsoDepListenActvParam rxParam;
-					rxParam.rxBuf = rxBufA;
-					rxParam.rxLen = &rxRcvdLen;
-					rxParam.isoDepDev = NULL;
-					rxParam.isRxChaining = &bIsRxChaining;
-					//
-					isoDepTxRxParam.FSx = rfalIsoDepFSxI2FSx(atsParam.fsci);
-					rfalIsoDepListenStartActivation( &atsParam, NULL, rxBuf_ce, rxRcvdLen, rxParam );
-				} else {
-					// idle/halt state for all the commands we "don't support"
-
-					int i, rxSize;
-					if (rxRcvdLen > 0) {
-						printf_dbg("RATS ignored...\r\n");
-
-						rxSize = rfalConvBitsToBytes(rxRcvdLen);
-						for (i = 0; i < (rxSize > 16? 16 : rxSize); i++)
-							printf_dbg(" %02X", rxBuf_ce[i]);
-						printf_dbg("\r\n");
-
-						if (state == RFAL_LM_STATE_ACTIVE_Ax) {
-							rfalListenSleepStart( RFAL_LM_STATE_SLEEP_A, rxBuf_ce, RX_BUF_LENGTH, &rxRcvdLen );
-						} else {
-							rfalListenSetState(RFAL_LM_STATE_IDLE);
-						}
-
-					}
-				}
-			} else if (true == rfalNfcaListenerIsSleepReq( rxBuf_ce, rfalConvBitsToBytes(rxRcvdLen) ) ) {
+				// prepare for RATS
+				rfalIsoDepListenActvParam rxParam;
+				rxParam.rxBuf = rxBufA;
+				rxParam.rxLen = &rxRcvdLen;
+				rxParam.isoDepDev = NULL;
+				rxParam.isRxChaining = &bIsRxChaining;
+				//
+				isoDepTxRxParam.FSx = rfalIsoDepFSxI2FSx(atsParam.fsci);
+				rfalIsoDepListenStartActivation(&atsParam, NULL, rxBuf_ce, rxRcvdLen, rxParam);
+			} else if (true == rfalNfcaListenerIsSleepReq(rxBuf_ce, rfalConvBitsToBytes(rxRcvdLen))) {
 				printf_dbg("HLTA\r\n");
-				rfalListenSleepStart( RFAL_LM_STATE_SLEEP_A, rxBuf_ce, RX_BUF_LENGTH, &rxRcvdLen );
+				rfalListenSleepStart(RFAL_LM_STATE_SLEEP_A, rxBuf_ce, RX_BUF_LENGTH, &rxRcvdLen);
 			} else {
 				int i, rxSize;
 				if (rxRcvdLen > 0) {
 					printf_dbg("Hndler A3 rx: ");
 
 					rxSize = rfalConvBitsToBytes(rxRcvdLen);
-					for (i = 0; i < (rxSize > 16? 16 : rxSize); i++)
+					for (i = 0; i < (rxSize > 16 ? 16 : rxSize); i++)
 						printf_dbg(" %02X", rxBuf_ce[i]);
 					printf_dbg("\r\n");
 				}
@@ -347,7 +282,7 @@ static void ceHandler( void )
 	//
 	case RFAL_LM_STATE_CARDEMU_4A : {
 		isActivatedA = true;
-		if(cardA_activated_ptr != NULL) {
+		if (cardA_activated_ptr != NULL) {
 			cardA_activated_ptr();
 		}
 		break;
@@ -358,74 +293,33 @@ static void ceHandler( void )
 	}
 }
 
-
-static void ceRun(t_hydra_console *con, bool quiet)
+static void ceRun(void)
 {
 	ReturnCode err = ERR_NONE;
 	uint16_t dataSize;
-	int i;
 
 	dispatcherInterruptHandler();
 
 	rfalWorker();
 	ceHandler();
 	dataSize = sizeof(rxtxFrameBuf);
-//	rxSize = 512;
+
 	err = ceGetRx(CARDEMULATION_CMD_GET_RX_A, rxtxFrameBuf, &dataSize);
 
-	if(dataSize > 0) {
-		for (i = 0; i < 10; i++)
-			printf_dbg(" %02X", rxtxFrameBuf[i]);
-		printf_dbg("\r\n");
-	}
-
-	if(err == ERR_NONE) {
-		printf_dbg("rx:");
-		for (i = 0; i < (dataSize > 16? 16 : dataSize); i++)
-			printf_dbg(" %02X", rxtxFrameBuf[i]);
-		printf_dbg("\r\n");
+	if (err == ERR_NONE) {
 
 		dataSize = (*current_processCmdPtr)(rxtxFrameBuf, dataSize, rxtxFrameBuf);
-		err = ceSetTx(CARDEMULATION_CMD_SET_TX_A,rxtxFrameBuf, dataSize);
+		ceSetTx(CARDEMULATION_CMD_SET_TX_A, rxtxFrameBuf, dataSize);
 
-		if(err != ERR_NONE) {
-			if( quiet != TRUE) {
-				cprintf(con, "ceSetTx err %d\r\n", err);
-			}
-		}
-		printf_dbg("ceSetTx err %d\r\n", err);
-		// dataSize in bits after processCmd()
-		dataSize = rfalConvBitsToBytes(dataSize);
-
-		printf_dbg("tx:");
-		for (i = 0; i < (dataSize > 16? 16 : dataSize); i++)
-			printf_dbg(" %02X", rxtxFrameBuf[i]);
-		printf_dbg("\r\n");
-
-	} else {
-		switch(err) {
-		case ERR_NOTFOUND:
-		case ERR_BUSY:
-		case ERR_SLEEP_REQ:
-		case ERR_LINK_LOSS:
-			break;
-		default:
-			if( quiet != TRUE) {
-				cprintf(con, "ceGetRx err %d\r\n", err);
-			}
-			printf_dbg("ceGetRx err %d\r\n", err);
-			break;
-		}
 	}
 }
 
-static void hydranfc_ce_set_processCmd_ptr(void * ptr)
+static void hydranfc_ce_set_processCmd_ptr(void *ptr)
 {
 	current_processCmdPtr = ptr;
 }
 
-
-static void ceInitalize( void )
+static void ceInit(void)
 {
 	transceiveCtx.txBuf = txBuf_ce;
 	transceiveCtx.txBufLen = 0;
@@ -437,8 +331,8 @@ static void ceInitalize( void )
 	transceiveCtx.flags = RFAL_TXRX_FLAGS_DEFAULT;
 	transceiveCtx.fwt = RFAL_FWT_NONE;
 
-	rxBufA = (rfalIsoDepBufFormat*)rxBuf_ce;
-	txBufA = (rfalIsoDepBufFormat*)txBuf_ce;
+	rxBufA = (rfalIsoDepBufFormat *) rxBuf_ce;
+	txBufA = (rfalIsoDepBufFormat *) txBuf_ce;
 
 	isoDepTxRxParam.rxBuf = rxBufA;
 	isoDepTxRxParam.rxLen = &rxRcvdLen;
@@ -447,11 +341,8 @@ static void ceInitalize( void )
 	isoDepTxRxParam.isRxChaining = &bIsRxChaining;
 	isoDepTxRxParam.isTxChaining = false;
 
-	//
 	configMask = 0;
-	emuMode = 0;
 	isActivatedA = false;
-	isFirstF_Frame = false;
 	isFirstA3_Frame = true;
 	rxReady = false;
 	txReady = false;
@@ -459,164 +350,59 @@ static void ceInitalize( void )
 	ceEnabled = false;
 }
 
-
-static ReturnCode ceStart(const uint8_t *rxData, const uint16_t rxSize)
+static ReturnCode ceStart(void)
 {
-	//
-	// rxData holds the emuMode and 4 TLV data sets (with TAG 4)
-	//
-	//   0         1              ..             ..             ..
-	// | EmuMode | TLV Config A | TLV Config B | TLV Config F | ATS |
-
-	//
-	uint8_t *config[4];
-	uint32_t maskValues[4] = {RFAL_LM_MASK_NFCA, RFAL_LM_MASK_NFCB, RFAL_LM_MASK_NFCF, 0};
-	uint16_t offset = 0;
-	configMask = 0;
-
-	// get emu mode and increase offset to automatically
-	// remove the emuMode byte when not needed anymore
-	emuMode = *rxData;
-	offset++;
-
-	// extract config data
-	int i;
-	for (i = 0; i < 4; i++) {
-		if (i < rxSize) {
-			if (rxData[(i*2) + 1 + offset] > 0) {
-				//
-				config[i] = (uint8_t *)&rxData[(i*2) + 2 + offset];
-				//
-				configMask |= maskValues[i];
-				offset += rxData[(i*2) + 1  + offset];
-			} else {
-				config[i] = NULL;
-			}
-		}
-	}
-
-	// store config's for later usage
-	(config[0] != NULL) ? ST_MEMCPY(&configA, config[0], sizeof(configA)) : ST_MEMSET(&configA, 0, sizeof(configA));
-	(config[1] != NULL) ? ST_MEMCPY(&configB, config[1], sizeof(configB)) : ST_MEMSET(&configB, 0, sizeof(configB));
-	(config[2] != NULL) ? ST_MEMCPY(&configF, config[2], sizeof(configF)) : ST_MEMSET(&configF, 0, sizeof(configF));
-
-	// finally check if ATS is received as well..
-	if(config[3] != NULL) {
-		atsParam.fsci = config[3][0];
-		atsParam.fwi = config[3][1];
-		atsParam.sfgi = config[3][2];
-		atsParam.ta = config[3][3];
-		atsParam.hbLen = config[3][4];
-		atsParam.didSupport = false;
-		ST_MEMCPY(histChar, &config[3][5], atsParam.hbLen);
-		atsParam.hb = histChar;
-	} else {
-		ST_MEMSET(&atsParam, 0, sizeof(atsParam));
-	}
 
 	// .. and go ..
 	ceEnabled = true;
 	rxRcvdLen = 0;
-	return rfalListenStart (configMask,
-	                        (rfalLmConfPA *)config[0],
-	                        (rfalLmConfPB *)config[1],
-	                        (rfalLmConfPF *)config[2],
-	                        rxBuf_ce,
-	                        rfalConvBytesToBits(RX_BUF_LENGTH),
-	                        &rxRcvdLen);
+	configMask = RFAL_LM_MASK_NFCA;
+	return rfalListenStart(configMask,
+	                       &configA,
+	                       NULL,
+	                       NULL,
+	                       rxBuf_ce,
+	                       rfalConvBytesToBits(RX_BUF_LENGTH),
+	                       &rxRcvdLen);
 }
 
-
-static ReturnCode ceStop( void )
+static ReturnCode ceStop(void)
 {
 	rfalListenStop();
-	ceInitalize();
+	ceInit();
 	return ERR_NONE;
 }
 
-static void bbio_iso4443_raw_ce_common(t_hydra_console *con, bool quiet)
+static void bbio_iso4443_raw_ce_common(void)
 {
 	ReturnCode err = ERR_NONE;
 
-	// NDEF/ ISO Level 4
-	uint8_t startCmd[] = {
-		CARDEMULATION_MODE_NDEF,                          // command : not used!
-		0x04, 0x0E,                                       // 11 bytes data
-		0x07,                                             // 7 bytes UIDs
-		0x02, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00, 0x00,         // UID
-		0x44, 0x00,                                       // ATQA (04 00 for 4 byte uid, 44 00 for 7 byte uid)
-		0x20,                                             // SAK (00 - UL, 08 - classic, 20 - ISO L4)
-		0x04, 0x00, 0x04, 0x00,                           // disable TypeB & Felica
-		0x04, 0x07,                                       // ATS length 7
-		0x08, 0x0A, 0x00, 0x00, 0x02, 's', 't'            // FSCI, FWI, SFGI, DRI, DSI, hist length, hist...
-	};
-	// ats = 07 78 00 80 00 73 74 00
-
-	// adjust params according to user setup
-	// startCmd is in TLV format, so no fixed offsets to the data, hence ugly hardcode
-	if (user_tag_properties.sak_len != 0) {
-		memcpy(&startCmd[16], user_tag_properties.sak, user_tag_properties.sak_len);
-	}
-	if (user_tag_properties.uid_len != 0) {
-		startCmd[3] = user_tag_properties.uid_len;
-		memcpy(&startCmd[4], user_tag_properties.uid, user_tag_properties.uid_len);
-		switch (user_tag_properties.uid_len) {
-		case 4:
-			startCmd[14] = 0x04;
-			break;
-		case 7:
-			startCmd[14] = 0x44;
-			break;
-		default:
-			break;
-		}
-	}
-
 	rfalFieldOff();
-	ceInitalize();
+	ceInit();
 	rfalIsoDepInitialize();
 
-	err = ceStart(startCmd, sizeof(startCmd));
+	err = ceStart();
 	if (err == ERR_NONE) {
-		if( quiet != TRUE) {
-			cprintf(con, "CE started. Press user button to stop.\r\n");
-		}
-
 		while (!hydrabus_ubtn()) {
-			ceRun(con, quiet);
+			ceRun();
 			chThdYield();
-			//		  chThdSleepMilliseconds(50);
 		}
 
 		ceStop();
-		if (quiet != TRUE) {
-			cprintf(con, "CE finished\r\n");
-		}
-	} else {
-		if (quiet != TRUE) {
-			cprintf(con, "CE failed: %d\r\n", err);
-		}
 	}
 }
 
-
-
-
-
-static void ce_set_cardA_activated_ptr(void * ptr)
+static void ce_set_cardA_activated_ptr(void *ptr)
 {
 	cardA_activated_ptr = ptr;
 }
 
-static rfalLmState state;
-
-
 /* Triggered when the Ext IRQ is pressed or released. */
-static void extcb1(void * arg)
+static void extcb1(void *arg)
 {
 	(void) arg;
 
-	if(st25r3916_irq_fn != NULL)
+	if (st25r3916_irq_fn != NULL)
 		st25r3916_irq_fn();
 
 	irq_count++;
@@ -624,7 +410,7 @@ static void extcb1(void * arg)
 }
 
 extern t_mode_config mode_con1;
-static t_hydra_console * g_con;
+static t_hydra_console *g_con;
 
 static ReturnCode hydranfc_v2_init_RFAL(t_hydra_console *con)
 {
@@ -632,7 +418,7 @@ static ReturnCode hydranfc_v2_init_RFAL(t_hydra_console *con)
 	/* RFAL initalisation */
 	rfalAnalogConfigInitialize();
 	err = rfalInitialize();
-	if(err != ERR_NONE) {
+	if (err != ERR_NONE) {
 		cprintf(con, "hydranfc_v2_init_RFAL rfalInitialize() error=%d\r\n", err);
 		return err;
 	}
@@ -651,7 +437,6 @@ static ReturnCode hydranfc_v2_init_RFAL(t_hydra_console *con)
 #endif
 	return err;
 }
-
 
 static bool init_gpio_spi_nfc(t_hydra_console *con)
 {
@@ -712,7 +497,7 @@ static bool init_gpio_spi_nfc(t_hydra_console *con)
 	palDisablePadEvent(GPIOA, 1);
 	/* ST25R3916 IRQ output / HydraBus PA1 input */
 	palClearPad(GPIOA, 1);
-	palSetPadMode(GPIOA, 1, PAL_MODE_INPUT | PAL_STM32_OSPEED_MID1);
+	palSetPadMode(GPIOA, 1, PAL_MODE_INPUT|PAL_STM32_OSPEED_MID1);
 	/* Activates the PAL driver callback */
 	//palDisablePadEvent(GPIOA, 1);
 	palEnablePadEvent(GPIOA, 1, PAL_EVENT_MODE_RISING_EDGE);
@@ -730,7 +515,7 @@ static bool init_gpio_spi_nfc(t_hydra_console *con)
 
 static void deinit_gpio_spi_nfc(t_hydra_console *con)
 {
-	(void)(con);
+	(void) (con);
 	palClearPad(GPIOA, 1);
 	palSetPadMode(GPIOA, 1, PAL_MODE_INPUT);
 	palDisablePadEvent(GPIOA, 1);
@@ -751,33 +536,45 @@ static void bbio_mode_id(t_hydra_console *con)
 
 static void init(void)
 {
-	memset(&user_tag_properties, 0, sizeof(user_tag_properties));
+	configA.nfcidLen = 4;
+	configA.nfcid[0] = 0xAA;
+	configA.nfcid[1] = 0xBB;
+	configA.nfcid[2] = 0xCC;
+	configA.nfcid[3] = 0xDD;
 
-	user_tag_properties.uid[0] = 0xAA;
-	user_tag_properties.uid[1] = 0xBB;
-	user_tag_properties.uid[2] = 0xCC;
-	user_tag_properties.uid[3] = 0xDD;
-	user_tag_properties.uid_len = 4;
+	configA.SENS_RES[0] = 0x04;
+	configA.SENS_RES[1] = 0x00;
 
-	user_tag_properties.sak[0] = 0x20;
-	user_tag_properties.sak_len = 1;
+	configA.SEL_RES = 0x20;
+
+	histChar[0] = 0x73;
+	histChar[0] = 0x74;
+
+	atsParam.fsci = 0x08;
+	atsParam.fwi = 0x0A;
+	atsParam.sfgi = 0x00;
+	atsParam.ta = 0x00;
+	atsParam.hbLen = 0x02;
+	atsParam.didSupport = 0x00;
+	atsParam.hb = histChar;
+
 }
 
 /* Main command management function */
-uint16_t bbio_processCmd(uint8_t *cmdData, uint16_t  cmdDatalen, uint8_t *rspData)
+uint16_t bbio_processCmd(uint8_t *cmdData, uint16_t cmdDatalen, uint8_t *rspData)
 {
 	uint16_t rspDataLen;
 	char cmd_byte = BBIO_NFC_CE_CARD_CMD;
 
 	cprint(g_con, &cmd_byte, 1);
 
-	cprint(g_con, (char*)&cmdDatalen, 2);
+	cprint(g_con, (char *) &cmdDatalen, 2);
 	cprint(g_con, (char *) cmdData, cmdDatalen);
 
-	chnRead(g_con->sdu, (uint8_t*)&rspDataLen, 2);
+	chnRead(g_con->sdu, (uint8_t * )&rspDataLen, 2);
 	chnRead(g_con->sdu, rspData, rspDataLen);
 
-	return rspDataLen*8;
+	return rspDataLen * 8;
 }
 
 static void cardA_activated(void)
@@ -806,8 +603,6 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 				/* Init st25r3916 IRQ function callback */
 				st25r3916_irq_fn = st25r3916Isr;
 
-				user_tag_properties.level4_enabled = true;
-
 				hydranfc_ce_set_processCmd_ptr(&bbio_processCmd);
 				ce_set_cardA_activated_ptr(&cardA_activated);
 				g_con = con;
@@ -824,12 +619,10 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 				/* Init st25r3916 IRQ function callback */
 				st25r3916_irq_fn = st25r3916Isr;
 
-				user_tag_properties.level4_enabled = true;
-
 				hydranfc_ce_set_processCmd_ptr(&bbio_processCmd);
 				ce_set_cardA_activated_ptr(&cardA_activated);
 				g_con = con;
-				bbio_iso4443_raw_ce_common(con, TRUE);
+				bbio_iso4443_raw_ce_common();
 
 				bbio_subcommand = BBIO_NFC_CE_END_EMULATION;
 				cprint(con, (char *) &bbio_subcommand, 1);
@@ -845,8 +638,8 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 				switch (clen) {
 				case 4:
 				case 7:
-					user_tag_properties.uid_len = clen;
-					memcpy(user_tag_properties.uid, rx_data, clen);
+					configA.nfcidLen = clen;
+					memcpy(configA.nfcid, rx_data, clen);
 					rx_data[0] = 0x01;
 					break;
 				default:
@@ -861,8 +654,7 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 				chnRead(con->sdu, &clen, 1);
 				chnRead(con->sdu, rx_data, clen);
 
-				user_tag_properties.sak[0] = rx_data[0];
-
+				configA.SEL_RES = rx_data[0];
 				rx_data[0] = 1;
 
 				cprint(con, (char *) rx_data, 1);

--- a/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
+++ b/src/hydranfc_v2/hydranfc_v2_bbio_card_emulator.c
@@ -24,7 +24,6 @@
 #include "hydrabus_bbio.h"
 #include "bsp_gpio.h"
 #include "hydranfc_v2_bbio_card_emulator.h"
-#include "hydranfc_v2_ce.h"
 #include "st25r3916.h"
 #include "st25r3916_irq.h"
 #include "st25r3916_com.h"
@@ -33,18 +32,584 @@
 #include "rfal_nfca.h"
 #include "rfal_nfcb.h"
 #include "rfal_nfcv.h"
-
+#include "string.h"
+#include "stdbool.h"
+#include "rfal_isoDep.h"
+#include "dispatcher.h"
+#include "stdlib.h"
+#include "utils.h"
+#include "bsp_print_dbg.h"
 #include <string.h>
+
+typedef enum {
+	T4T_MODE_NOT_SET = 0,
+	T4T_MODE_URI,
+	T4T_MODE_EMAIL
+} eT4TEmulationMode;
+
+enum cardEmulationMode {
+	CARDEMULATION_MODE_NDEF                     = 0x01,
+	CARDEMULATION_MODE_REFLECT                  = 0x02,
+	CARDEMULATION_PROCESS_INTERNAL              = 0x80,
+};
+
+enum cardEmulationCommand {
+	CARDEMULATION_CMD_START                     = 0x01, /*!< start listen mode. */
+	CARDEMULATION_CMD_STOP                      = 0x02, /*!< stop listen mode. */
+
+	CARDEMULATION_CMD_GET_RX_A                  = 0x11,
+	CARDEMULATION_CMD_SET_TX_A                  = 0x12,
+	CARDEMULATION_CMD_GET_RX_B                  = 0x13,
+	CARDEMULATION_CMD_SET_TX_B                  = 0x14,
+	CARDEMULATION_CMD_GET_RX_F                  = 0x15,
+	CARDEMULATION_CMD_SET_TX_F                  = 0x16,
+
+	CARDEMULATION_CMD_GET_LISTEN_STATE          = 0x21,
+};
+
+typedef struct {
+	uint32_t uid_len;
+	uint8_t uid[8];
+	uint32_t sak_len; // 0 or 1
+	uint8_t sak[1];
+	uint8_t *uri;
+	bool level4_enabled;
+	eT4TEmulationMode t4tEmulationMode;
+} sUserTagProperties;
+
 
 static volatile int irq_count;
 static volatile int irq;
 static volatile int irq_end_rx;
-
 static void (* st25r3916_irq_fn)(void) = NULL;
+#define TX_BUF_LENGTH       (256+3)
+static uint8_t txBuf_ce[TX_BUF_LENGTH] __attribute__ ((section(".cmm")));
 
-extern sUserTagProperties user_tag_properties;
-extern void hydranfc_ce_set_processCmd_ptr(void * ptr);
-extern void ce_set_cardA_activated_ptr(void * ptr);
+#define RX_BUF_LENGTH       (256+3)
+static uint8_t rxBuf_ce[RX_BUF_LENGTH] __attribute__ ((section(".cmm")));
+static uint16_t rxRcvdLen = 0;
+static bool  ceEnabled;
+static sUserTagProperties user_tag_properties;
+static rfalLmState state;
+static rfalLmConfPA                            configA;
+static rfalLmConfPB                            configB;
+static rfalLmConfPF                            configF;
+static rfalIsoDepAtsParam                      atsParam;
+static uint8_t                                 histChar[16];
+static uint32_t                                configMask = 0;
+static rfalTransceiveContext                   transceiveCtx;
+
+static uint8_t                                 emuMode = 0;
+
+static rfalIsoDepBufFormat                     *rxBufA;
+static rfalIsoDepBufFormat                     *txBufA;
+static bool                                    bIsRxChaining;
+static bool                                    isActivatedA = false;
+static bool                                    isFirstF_Frame = false;
+static bool                                    isFirstA3_Frame = true;
+static rfalIsoDepTxRxParam                     isoDepTxRxParam;
+
+static bool                                    rxReady = false;
+static bool                                    txReady = false;
+
+static rfalLmState statePrev = RFAL_LM_STATE_NOT_INIT;
+static rfalTransceiveState     tStateCur = 3;
+static rfalTransceiveState     tStatePrev = 3;
+
+static uint16_t (*cardA_activated_ptr)(void) = NULL;
+
+static uint8_t rxtxFrameBuf[512] __attribute__ ((section(".cmm")));
+
+uint16_t bbio_processCmd(uint8_t *cmdData, uint16_t  cmdDataLen, uint8_t *rspData);
+static uint16_t (*current_processCmdPtr)(uint8_t *, uint16_t, uint8_t *) = bbio_processCmd;
+
+
+static uint16_t dispatcherInterruptResults[32];
+
+static sUserTagProperties user_tag_properties;
+
+void hydranfc_ce_common(t_hydra_console *con, bool quiet);
+static const uint8_t dispatcherInterruptResultRegs[32]= {
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff, /* 1st byte */
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff, /* 2nd byte */
+	ST25R3916_REG_CAPACITANCE_MEASURE_RESULT,
+	ST25R3916_REG_PHASE_MEASURE_RESULT,
+	ST25R3916_REG_AMPLITUDE_MEASURE_RESULT,0xff,0xff,0xff,0xff,0xff, /* 3rd byte */
+	0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff, /* 4th byte */
+};
+
+static void dispatcherInterruptHandler(void)
+{
+	int i;
+	uint8_t val;
+	uint16_t isrs;
+
+	for (i=0; i<32; i++) { /* !!!!!!!!!!!!!!!!! */
+		if(dispatcherInterruptResultRegs[i] >= 0x40) continue;
+		if(!st25r3916GetInterrupt(1UL<<i)) continue;
+
+		isrs = dispatcherInterruptResults[i] >> 8;
+		if (isrs < 255) isrs++;
+
+		st25r3916ReadRegister(dispatcherInterruptResultRegs[i], &val);
+
+		dispatcherInterruptResults[i] = (isrs<<8) | val;
+	}
+}
+
+
+static ReturnCode ceGetRx(const uint8_t cmd, uint8_t *txData, uint16_t *txSize)
+{
+	ReturnCode err = ERR_NOTFOUND;
+	switch (cmd) {
+	case CARDEMULATION_CMD_GET_RX_A:
+		if(isActivatedA) {
+			//err = rfalIsoDepGetTransceiveStatus();
+			err = rfalIsoDepGetTransceiveStatusRawMode();
+
+			switch (err) {
+			case ERR_SLEEP_REQ:
+			// TBC if ok going to idle state rather than to sleep state!
+			case ERR_LINK_LOSS:
+			default:
+				rfalListenStop();
+				rfalListenStart(configMask, &configA, &configB, &configF, rxBuf_ce, rfalConvBytesToBits(RX_BUF_LENGTH), &rxRcvdLen);
+				rxReady = txReady = isActivatedA = false;
+				isFirstA3_Frame = true;
+				printf_dbg("LLoss3 %d\r\n", err);
+				break;
+
+			case ERR_BUSY:           /* Transceive ongoing                              */
+			case ERR_AGAIN:          /* Chaining packet received - handling to be added */
+				break;
+
+			case ERR_NONE:
+				ST_MEMCPY(txData, isoDepTxRxParam.rxBuf->inf, *isoDepTxRxParam.rxLen);
+				ST_MEMCPY(txData, isoDepTxRxParam.rxBuf, *isoDepTxRxParam.rxLen);
+
+				*txSize = *isoDepTxRxParam.rxLen;
+
+				rxReady = false;
+				txReady = true;
+				break;
+			}
+
+		} else {
+			// handle layer3 comms here
+			if(isFirstA3_Frame) {
+				// IMPORTANT: We can not call rfalGetTransceiveStatus before we did the first
+				// call rfalStartTransceive
+
+				err = ERR_NONE;
+
+				if (rxReady) {
+					ST_MEMCPY(txData, transceiveCtx.rxBuf, *transceiveCtx.rxRcvdLen);
+					*txSize = rfalConvBitsToBytes(*transceiveCtx.rxRcvdLen);
+
+					rxReady = false;
+					txReady = true;
+				} else {
+					*txSize = 0;
+					err = ERR_BUSY; // no data available yet
+				}
+
+				// NOTE: isFirstA3_Frame is cleared after the first transmit is done.
+				// For this mode this transmit is done within the rfalStartTransceive
+				// function in ceSetTx(..)
+
+			}
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+static ReturnCode ceSetTx(const uint8_t cmd, const uint8_t * rxData, const uint16_t rxSize)
+{
+	ReturnCode err = ERR_NOTFOUND;
+	uint16_t rxSizeBytes = rfalConvBitsToBytes(rxSize);
+
+	switch (cmd) {
+	case CARDEMULATION_CMD_SET_TX_A:
+		if(isActivatedA) {
+			if (txReady) {
+				ST_MEMCPY(isoDepTxRxParam.txBuf->inf, rxData, rxSizeBytes);
+				isoDepTxRxParam.txBufLen = rxSizeBytes;
+				*isoDepTxRxParam.rxLen = 0;
+				err = rfalIsoDepStartTransceive(isoDepTxRxParam);
+
+				if(err == ERR_NONE) {
+					rxReady = txReady = false;
+				}
+			}
+		}
+		break;
+
+	default:
+		break;
+	}
+	return err;
+}
+
+
+
+static void ceHandler( void )
+{
+	bool dataFlag = false;
+
+	/* Check whether CE is enabled */
+	if( !ceEnabled ) {
+		return;
+	}
+
+	state = rfalListenGetState(&dataFlag, NULL);
+	if (state != statePrev) {
+		// new state
+		printf_dbg("rLGS %d\r\n", state);
+		statePrev = state;
+	}
+	tStateCur = rfalGetTransceiveState( );
+	if (tStateCur != tStatePrev) {
+		// new state
+		printf_dbg("rGTS %d\r\n", tStateCur);
+		tStatePrev = tStateCur;
+	}
+
+
+	switch (state) {
+	// ------------------------------------------------------------------
+	// NFC A
+	// ------------------------------------------------------------------
+	//
+	case RFAL_LM_STATE_ACTIVE_A:
+	case RFAL_LM_STATE_ACTIVE_Ax: {
+		if(dataFlag == true) {
+			if (rfalIsoDepIsRats(rxBuf_ce, rfalConvBitsToBytes(rxRcvdLen))) {
+				if (user_tag_properties.level4_enabled) {
+					printf_dbg("RATS!\r\n");
+
+					// enter next already state
+					rfalListenSetState(RFAL_LM_STATE_CARDEMU_4A);
+
+					// prepare for RATS
+					rfalIsoDepListenActvParam rxParam;
+					rxParam.rxBuf = rxBufA;
+					rxParam.rxLen = &rxRcvdLen;
+					rxParam.isoDepDev = NULL;
+					rxParam.isRxChaining = &bIsRxChaining;
+					//
+					isoDepTxRxParam.FSx = rfalIsoDepFSxI2FSx(atsParam.fsci);
+					rfalIsoDepListenStartActivation( &atsParam, NULL, rxBuf_ce, rxRcvdLen, rxParam );
+				} else {
+					// idle/halt state for all the commands we "don't support"
+
+					int i, rxSize;
+					if (rxRcvdLen > 0) {
+						printf_dbg("RATS ignored...\r\n");
+
+						rxSize = rfalConvBitsToBytes(rxRcvdLen);
+						for (i = 0; i < (rxSize > 16? 16 : rxSize); i++)
+							printf_dbg(" %02X", rxBuf_ce[i]);
+						printf_dbg("\r\n");
+
+						if (state == RFAL_LM_STATE_ACTIVE_Ax) {
+							rfalListenSleepStart( RFAL_LM_STATE_SLEEP_A, rxBuf_ce, RX_BUF_LENGTH, &rxRcvdLen );
+						} else {
+							rfalListenSetState(RFAL_LM_STATE_IDLE);
+						}
+
+					}
+				}
+			} else if (true == rfalNfcaListenerIsSleepReq( rxBuf_ce, rfalConvBitsToBytes(rxRcvdLen) ) ) {
+				printf_dbg("HLTA\r\n");
+				rfalListenSleepStart( RFAL_LM_STATE_SLEEP_A, rxBuf_ce, RX_BUF_LENGTH, &rxRcvdLen );
+			} else {
+				int i, rxSize;
+				if (rxRcvdLen > 0) {
+					printf_dbg("Hndler A3 rx: ");
+
+					rxSize = rfalConvBitsToBytes(rxRcvdLen);
+					for (i = 0; i < (rxSize > 16? 16 : rxSize); i++)
+						printf_dbg(" %02X", rxBuf_ce[i]);
+					printf_dbg("\r\n");
+				}
+
+				// not HLTA and not RATS - layer3 comms
+				rxReady = true;
+			}
+		}
+		break;
+	}
+	//
+	case RFAL_LM_STATE_CARDEMU_4A : {
+		isActivatedA = true;
+		if(cardA_activated_ptr != NULL) {
+			cardA_activated_ptr();
+		}
+		break;
+	}
+
+	default:
+		break;
+	}
+}
+
+
+static void ceRun(t_hydra_console *con, bool quiet)
+{
+	ReturnCode err = ERR_NONE;
+	uint16_t dataSize;
+	int i;
+
+	dispatcherInterruptHandler();
+
+	rfalWorker();
+	ceHandler();
+	dataSize = sizeof(rxtxFrameBuf);
+//	rxSize = 512;
+	err = ceGetRx(CARDEMULATION_CMD_GET_RX_A, rxtxFrameBuf, &dataSize);
+
+	if(dataSize > 0) {
+		for (i = 0; i < 10; i++)
+			printf_dbg(" %02X", rxtxFrameBuf[i]);
+		printf_dbg("\r\n");
+	}
+
+	if(err == ERR_NONE) {
+		printf_dbg("rx:");
+		for (i = 0; i < (dataSize > 16? 16 : dataSize); i++)
+			printf_dbg(" %02X", rxtxFrameBuf[i]);
+		printf_dbg("\r\n");
+
+		dataSize = (*current_processCmdPtr)(rxtxFrameBuf, dataSize, rxtxFrameBuf);
+		err = ceSetTx(CARDEMULATION_CMD_SET_TX_A,rxtxFrameBuf, dataSize);
+
+		if(err != ERR_NONE) {
+			if( quiet != TRUE) {
+				cprintf(con, "ceSetTx err %d\r\n", err);
+			}
+		}
+		printf_dbg("ceSetTx err %d\r\n", err);
+		// dataSize in bits after processCmd()
+		dataSize = rfalConvBitsToBytes(dataSize);
+
+		printf_dbg("tx:");
+		for (i = 0; i < (dataSize > 16? 16 : dataSize); i++)
+			printf_dbg(" %02X", rxtxFrameBuf[i]);
+		printf_dbg("\r\n");
+
+	} else {
+		switch(err) {
+		case ERR_NOTFOUND:
+		case ERR_BUSY:
+		case ERR_SLEEP_REQ:
+		case ERR_LINK_LOSS:
+			break;
+		default:
+			if( quiet != TRUE) {
+				cprintf(con, "ceGetRx err %d\r\n", err);
+			}
+			printf_dbg("ceGetRx err %d\r\n", err);
+			break;
+		}
+	}
+}
+
+static void hydranfc_ce_set_processCmd_ptr(void * ptr)
+{
+	current_processCmdPtr = ptr;
+}
+
+
+static void ceInitalize( void )
+{
+	transceiveCtx.txBuf = txBuf_ce;
+	transceiveCtx.txBufLen = 0;
+
+	transceiveCtx.rxBuf = rxBuf_ce;
+	transceiveCtx.rxBufLen = RX_BUF_LENGTH;
+	transceiveCtx.rxRcvdLen = &rxRcvdLen;
+
+	transceiveCtx.flags = RFAL_TXRX_FLAGS_DEFAULT;
+	transceiveCtx.fwt = RFAL_FWT_NONE;
+
+	rxBufA = (rfalIsoDepBufFormat*)rxBuf_ce;
+	txBufA = (rfalIsoDepBufFormat*)txBuf_ce;
+
+	isoDepTxRxParam.rxBuf = rxBufA;
+	isoDepTxRxParam.rxLen = &rxRcvdLen;
+	isoDepTxRxParam.txBuf = txBufA;
+	isoDepTxRxParam.ourFSx = RFAL_ISODEP_FSX_KEEP;
+	isoDepTxRxParam.isRxChaining = &bIsRxChaining;
+	isoDepTxRxParam.isTxChaining = false;
+
+	//
+	configMask = 0;
+	emuMode = 0;
+	isActivatedA = false;
+	isFirstF_Frame = false;
+	isFirstA3_Frame = true;
+	rxReady = false;
+	txReady = false;
+
+	ceEnabled = false;
+}
+
+
+static ReturnCode ceStart(const uint8_t *rxData, const uint16_t rxSize)
+{
+	//
+	// rxData holds the emuMode and 4 TLV data sets (with TAG 4)
+	//
+	//   0         1              ..             ..             ..
+	// | EmuMode | TLV Config A | TLV Config B | TLV Config F | ATS |
+
+	//
+	uint8_t *config[4];
+	uint32_t maskValues[4] = {RFAL_LM_MASK_NFCA, RFAL_LM_MASK_NFCB, RFAL_LM_MASK_NFCF, 0};
+	uint16_t offset = 0;
+	configMask = 0;
+
+	// get emu mode and increase offset to automatically
+	// remove the emuMode byte when not needed anymore
+	emuMode = *rxData;
+	offset++;
+
+	// extract config data
+	int i;
+	for (i = 0; i < 4; i++) {
+		if (i < rxSize) {
+			if (rxData[(i*2) + 1 + offset] > 0) {
+				//
+				config[i] = (uint8_t *)&rxData[(i*2) + 2 + offset];
+				//
+				configMask |= maskValues[i];
+				offset += rxData[(i*2) + 1  + offset];
+			} else {
+				config[i] = NULL;
+			}
+		}
+	}
+
+	// store config's for later usage
+	(config[0] != NULL) ? ST_MEMCPY(&configA, config[0], sizeof(configA)) : ST_MEMSET(&configA, 0, sizeof(configA));
+	(config[1] != NULL) ? ST_MEMCPY(&configB, config[1], sizeof(configB)) : ST_MEMSET(&configB, 0, sizeof(configB));
+	(config[2] != NULL) ? ST_MEMCPY(&configF, config[2], sizeof(configF)) : ST_MEMSET(&configF, 0, sizeof(configF));
+
+	// finally check if ATS is received as well..
+	if(config[3] != NULL) {
+		atsParam.fsci = config[3][0];
+		atsParam.fwi = config[3][1];
+		atsParam.sfgi = config[3][2];
+		atsParam.ta = config[3][3];
+		atsParam.hbLen = config[3][4];
+		atsParam.didSupport = false;
+		ST_MEMCPY(histChar, &config[3][5], atsParam.hbLen);
+		atsParam.hb = histChar;
+	} else {
+		ST_MEMSET(&atsParam, 0, sizeof(atsParam));
+	}
+
+	// .. and go ..
+	ceEnabled = true;
+	rxRcvdLen = 0;
+	return rfalListenStart (configMask,
+	                        (rfalLmConfPA *)config[0],
+	                        (rfalLmConfPB *)config[1],
+	                        (rfalLmConfPF *)config[2],
+	                        rxBuf_ce,
+	                        rfalConvBytesToBits(RX_BUF_LENGTH),
+	                        &rxRcvdLen);
+}
+
+
+static ReturnCode ceStop( void )
+{
+	rfalListenStop();
+	ceInitalize();
+	return ERR_NONE;
+}
+
+static void bbio_iso4443_raw_ce_common(t_hydra_console *con, bool quiet)
+{
+	ReturnCode err = ERR_NONE;
+
+	// NDEF/ ISO Level 4
+	uint8_t startCmd[] = {
+		CARDEMULATION_MODE_NDEF,                          // command : not used!
+		0x04, 0x0E,                                       // 11 bytes data
+		0x07,                                             // 7 bytes UIDs
+		0x02, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x00, 0x00, 0x00,         // UID
+		0x44, 0x00,                                       // ATQA (04 00 for 4 byte uid, 44 00 for 7 byte uid)
+		0x20,                                             // SAK (00 - UL, 08 - classic, 20 - ISO L4)
+		0x04, 0x00, 0x04, 0x00,                           // disable TypeB & Felica
+		0x04, 0x07,                                       // ATS length 7
+		0x08, 0x0A, 0x00, 0x00, 0x02, 's', 't'            // FSCI, FWI, SFGI, DRI, DSI, hist length, hist...
+	};
+	// ats = 07 78 00 80 00 73 74 00
+
+	// adjust params according to user setup
+	// startCmd is in TLV format, so no fixed offsets to the data, hence ugly hardcode
+	if (user_tag_properties.sak_len != 0) {
+		memcpy(&startCmd[16], user_tag_properties.sak, user_tag_properties.sak_len);
+	}
+	if (user_tag_properties.uid_len != 0) {
+		startCmd[3] = user_tag_properties.uid_len;
+		memcpy(&startCmd[4], user_tag_properties.uid, user_tag_properties.uid_len);
+		switch (user_tag_properties.uid_len) {
+		case 4:
+			startCmd[14] = 0x04;
+			break;
+		case 7:
+			startCmd[14] = 0x44;
+			break;
+		default:
+			break;
+		}
+	}
+
+	rfalFieldOff();
+	ceInitalize();
+	rfalIsoDepInitialize();
+
+	err = ceStart(startCmd, sizeof(startCmd));
+	if (err == ERR_NONE) {
+		if( quiet != TRUE) {
+			cprintf(con, "CE started. Press user button to stop.\r\n");
+		}
+
+		while (!hydrabus_ubtn()) {
+			ceRun(con, quiet);
+			chThdYield();
+			//		  chThdSleepMilliseconds(50);
+		}
+
+		ceStop();
+		if (quiet != TRUE) {
+			cprintf(con, "CE finished\r\n");
+		}
+	} else {
+		if (quiet != TRUE) {
+			cprintf(con, "CE failed: %d\r\n", err);
+		}
+	}
+}
+
+
+
+
+
+static void ce_set_cardA_activated_ptr(void * ptr)
+{
+	cardA_activated_ptr = ptr;
+}
+
+static rfalLmState state;
+
 
 /* Triggered when the Ext IRQ is pressed or released. */
 static void extcb1(void * arg)
@@ -199,7 +764,7 @@ static void init(void)
 }
 
 /* Main command management function */
-static uint16_t processCmd(uint8_t *cmdData, uint16_t  cmdDatalen, uint8_t *rspData)
+uint16_t bbio_processCmd(uint8_t *cmdData, uint16_t  cmdDatalen, uint8_t *rspData)
 {
 	uint16_t rspDataLen;
 	char cmd_byte = BBIO_NFC_CE_CARD_CMD;
@@ -243,10 +808,28 @@ void bbio_mode_hydranfc_v2_card_emulator(t_hydra_console *con)
 
 				user_tag_properties.level4_enabled = true;
 
-				hydranfc_ce_set_processCmd_ptr(&processCmd);
+				hydranfc_ce_set_processCmd_ptr(&bbio_processCmd);
 				ce_set_cardA_activated_ptr(&cardA_activated);
 				g_con = con;
 				hydranfc_ce_common(con, TRUE);
+
+				bbio_subcommand = BBIO_NFC_CE_END_EMULATION;
+				cprint(con, (char *) &bbio_subcommand, 1);
+
+				irq_count = 0;
+				st25r3916_irq_fn = NULL;
+				break;
+
+			case BBIO_NFC_CE_START_EMULATION_RAW:
+				/* Init st25r3916 IRQ function callback */
+				st25r3916_irq_fn = st25r3916Isr;
+
+				user_tag_properties.level4_enabled = true;
+
+				hydranfc_ce_set_processCmd_ptr(&bbio_processCmd);
+				ce_set_cardA_activated_ptr(&cardA_activated);
+				g_con = con;
+				bbio_iso4443_raw_ce_common(con, TRUE);
 
 				bbio_subcommand = BBIO_NFC_CE_END_EMULATION;
 				cprint(con, (char *) &bbio_subcommand, 1);

--- a/src/hydranfc_v2/rfal/STSW-ST25RFAL002.txt
+++ b/src/hydranfc_v2/rfal/STSW-ST25RFAL002.txt
@@ -1,3 +1,4 @@
 en.STSW-ST25RFAL002 V2.2.0 / 22-May-2020 https://www.st.com/en/embedded-software/stsw-st25rfal002.html
 B.VERNOUX June 2020 src\st25r3916\st25r3916.c fixed ST25R3916_TEST_TMR_TOUT_8FC
 B.VERNOUX June 2020 src\rfal_analogConfig.c fixed rfalAnalogConfigInitialize() when RFAL_ANALOG_CONFIG_CUSTOM is defined
+G.VINET September 2020 src\rfal_isoDep.c add isoDepTxRawMode, rfalIsoDepGetTransceiveStatusRawMode, isoDepDataExchangePICCRawMode

--- a/src/hydranfc_v2/rfal/inc/rfal_isoDep.h
+++ b/src/hydranfc_v2/rfal/inc/rfal_isoDep.h
@@ -637,6 +637,7 @@ uint16_t rfalIsoDepGetMaxInfLen( void );
  */
 ReturnCode rfalIsoDepStartTransceive( rfalIsoDepTxRxParam param );
 
+ReturnCode rfalIsoDepGetTransceiveStatusRawMode( void );
 
 /*!
  *****************************************************************************


### PR DESCRIPTION
# BBIO card emulation ISO 14443-A - RAW MODE

* From the PPS, we can receive/send raw TPDU command instead of APDUs.
* In a next version, we will add the RATS as well

An example is given in contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_raw_example.py