### PR TITLE
bbio-card-emulator-fix-and-features

### DIFF
--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_example.py
@@ -35,13 +35,19 @@ enter_bbio(ser)
 
 uid = bytes.fromhex("DEADBEEF")
 print(f"Set UID to {uid.hex()}")
-ser.write(b"\04" + b"\04" + uid)
+ser.write(b"\x04" + b"\x04" + uid)
 resp = ser.read(1)
 assert resp[0] == 0x01
 
 sak = b"\x21"
 print(f"Set SAK to {sak.hex()}")
-ser.write(b"\05" + b"\01" + sak)
+ser.write(b"\x05" + b"\x01" + sak)
+resp = ser.read(1)
+assert resp[0] == 0x01
+
+ats_hist_bytes = bytes("HydraNFC", "ascii")
+print(f"Set ATS Historical bytes to {ats_hist_bytes.hex()}")
+ser.write(b"\x0B" + bytes([len(ats_hist_bytes)]) + ats_hist_bytes)
 resp = ser.read(1)
 assert resp[0] == 0x01
 

--- a/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_raw_example.py
+++ b/contrib/bbio_hydranfc/bbio_hydranfc_card_emulator_iso_14443_a_raw_example.py
@@ -8,7 +8,7 @@
 #
 import serial
 
-port = "/dev/ttyACM2"
+port = "/dev/ttyACM1"
 
 ser = serial.Serial(port, timeout=None)
 
@@ -35,13 +35,19 @@ enter_bbio(ser)
 
 uid = bytes.fromhex("DEADBEEF")
 print(f"Set UID to {uid.hex()}")
-ser.write(b"\04" + b"\04" + uid)
+ser.write(b"\x04" + b"\x04" + uid)
 resp = ser.read(1)
 assert resp[0] == 0x01
 
 sak = b"\x21"
 print(f"Set SAK to {sak.hex()}")
-ser.write(b"\05" + b"\01" + sak)
+ser.write(b"\x05" + b"\x01" + sak)
+resp = ser.read(1)
+assert resp[0] == 0x01
+
+ats_hist_bytes = bytes("HydraNFC", "ascii")
+print(f"Set ATS Historical bytes to {ats_hist_bytes.hex()}")
+ser.write(b"\x0B" + bytes([len(ats_hist_bytes)]) + ats_hist_bytes)
 resp = ser.read(1)
 assert resp[0] == 0x01
 

--- a/src/hydrabus/hydrabus_bbio.h
+++ b/src/hydrabus/hydrabus_bbio.h
@@ -204,5 +204,6 @@
 #define BBIO_NFC_CE_CARD_CMD           0b00001000
 #define BBIO_NFC_CE_END_EMULATION      0b00001001
 #define BBIO_NFC_CE_START_EMULATION_RAW 0b00001010
+#define BBIO_NFC_CE_SET_ATS_HIST_BYTES  0b00001011
 
 int cmd_bbio(t_hydra_console *con);


### PR DESCRIPTION
## Fix

* APDU mode was not more working with latest version.
* In raw mode, the command after the ATS is sometimes not correctly managed with smartphone. So, the PPS negotiation is automatically done. After, that we can send/receive raw command.

## features 

* add ATS historical bytes customization command

## chores

The code of APDU mode was moved into hydranfc_v2_bbio_card_emulator.c